### PR TITLE
Add Publish Config Public

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "LICENSE-3rdparty.csv",
     "NOTICE"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "bugs": {
     "url": "https://github.com/DataDog/datadog-serverless-compat-js/issues"
   },


### PR DESCRIPTION
### What does this PR do?

Add publish config public to `package.json`.

### Motivation

```
➤ YN0035: You must sign up for private packages
➤ YN0035:   Response Code: 402 (Payment Required)
➤ YN0035:   Request Method: PUT
➤ YN0035:   Request URL: https://registry.yarnpkg.com/@datadog%2fserverless-compat
```

### Additional Notes

### Describe how to test/QA your changes