### PR TITLE
Add Executable Permissions to Serverless Compat Binaries

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,9 @@ jobs:
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: "18.x"
+      - run: |
+          chmod +x bin/linux-amd64/datadog-serverless-compat
+          chmod +x bin/windows-amd64/datadog-serverless-compat.exe
       - run: yarn config set npmAuthToken $NPM_PUBLISH_TOKEN
         env:
           NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/serverless-compat",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Datadog Serverless Compatibility Layer to Enable Tracing and Metrics in Node.js",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
### What does this PR do?

Add executable permissions to serverless compat binaries.

### Motivation

Fixes a bug which prevents the serverless compat binaries from being executed due to missing permissions.

### Additional Notes

When testing locally these binaries already had the executable permissions set. When the files were copied into the package during the Github Action they did not have these same executable permissions.

### Describe how to test/QA your changes

See [README](https://github.com/DataDog/datadog-serverless-compat-js/blob/main/README.md)

Tested in the following environments:
- Azure Function / Linux / Consumption ✅ 
- Azure Function / Linux / Premium ✅ 
- Azure Function / Windows / Consumption ✅ 
- Azure Function / Windows / Premium ✅ 
- Google Cloud Run Function (1st gen) ✅ 