### PR TITLE
Pass serverless compat version to binary via environment variable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,22 @@ function getBinaryPath() {
     return binaryPath
 }
 
+// Pass package version to binary via environment variable
+function setPackageVersion() {
+    let packageVersion
+
+    try {
+        const { version } = require('../package.json');
+        packageVersion = version;
+    } catch (err) {
+        logger.error(`Unable to identify package version: ${err}`)
+        packageVersion = "unknown";
+    }
+
+    logger.debug(`Setting DD_SERVERLESS_COMPAT_VERSION to ${packageVersion}`)
+    process.env.DD_SERVERLESS_COMPAT_VERSION = packageVersion
+}
+
 function start() {
     const environment = getEnvironment()
     logger.debug(`Environment detected: ${environment}`)
@@ -65,6 +81,8 @@ function start() {
         logger.error(`Serverless Compatibility Layer did not start, could not find binary at path ${binaryPath}`)
         return
     }
+
+    setPackageVersion()
 
     try {
         childProcess.spawn(binaryPath, { stdio: 'inherit' })


### PR DESCRIPTION
### What does this PR do?

Set `DD_SERVERLESS_COMPAT_VERSION` to the currently installed package version.

### Motivation

https://datadoghq.atlassian.net/browse/SVLS-6326

### Additional Notes

Previously the version was set to the binary version. Since these packages were introduced it would be useful for troubleshooting to track the package versions installed by users. Since a specific version of the binary is packaged in each package version we can still trace back the binary version via the package version.

### Describe how to test/QA your changes

<!-- How was the change validated? Are there automated tests to prevent regressions? -->
