### PR TITLE
chore: use binaries from serverless-components in release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ on:
 permissions: {}
 
 jobs:
-  build:
+  downloadbinaries:
     runs-on: ubuntu-latest
     outputs:
       package-version: ${{ steps.package.outputs.package-version }}
@@ -40,10 +40,28 @@ jobs:
         with:
           name: bin
           path: bin
+  build:
+    runs-on: ubuntu-latest
+    needs: [downloadbinaries]
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: "18.x"
+      - run: yarn config set npmAuthToken $NPM_PUBLISH_TOKEN
+        env:
+          NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+      - run: yarn
+      - run: yarn pack
+      - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: package
+          path: package.tgz
   publish:
     if: ${{ github.event.inputs.publish-package == 'Build and Publish' }}
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [downloadbinaries]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,16 @@
 name: Publish packages on NPM
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      publish-package:
+        description: "Build or Build and Publish?"
+        required: true
+        type: choice
+        default: "Build"
+        options:
+          - "Build"
+          - "Build and Publish"
 
 permissions: {}
 
@@ -18,23 +28,20 @@ jobs:
           echo "package-version=$PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
       - id: serverless-compat-binary
         run: |
-          LIBDATADOG_RESPONSE=$(curl -s "https://api.github.com/repos/datadog/libdatadog/releases")
-          SERVERLESS_COMPAT_VERSION=$(echo "$LIBDATADOG_RESPONSE" | jq -r --arg pattern "sls-v[0-9]*\.[0-9]*\.[0-9]*" '.[] | select(.tag_name | test($pattern)) | .tag_name' | sort -V | tail -n 1)
+          RESPONSE=$(curl -s "https://api.github.com/repos/datadog/serverless-components/releases")
+          SERVERLESS_COMPAT_VERSION=$(echo "$RESPONSE" | jq -r --arg pattern "datadog-serverless-compat\/v[0-9]*\.[0-9]*\.[0-9]*" '.[] | select(.tag_name | test($pattern)) | .tag_name' | sort -V | tail -n 1)
 
           echo "Using version ${SERVERLESS_COMPAT_VERSION} of Serverless Compatibility Layer binary"
           echo "serverless-compat-version=$(echo "$SERVERLESS_COMPAT_VERSION" | jq -rR 'ltrimstr("sls-")')" >> "$GITHUB_OUTPUT"
 
-          curl --output-dir ./temp/ --create-dirs -O -s -L "https://github.com/DataDog/libdatadog/releases/download/${SERVERLESS_COMPAT_VERSION}/datadog-serverless-agent.zip"
-          unzip ./temp/datadog-serverless-agent.zip -d ./temp/datadog-serverless-agent
-
-          mkdir -p bin/linux-amd64 bin/windows-amd64
-          cp ./temp/datadog-serverless-agent/datadog-serverless-agent-linux-amd64/datadog-serverless-trace-mini-agent bin/linux-amd64/datadog-serverless-compat
-          cp ./temp/datadog-serverless-agent/datadog-serverless-agent-windows-amd64/datadog-serverless-trace-mini-agent.exe bin/windows-amd64/datadog-serverless-compat.exe
+          curl --output-dir ./temp/ --create-dirs -O -s -L "https://github.com/DataDog/serverless-components/releases/download/${SERVERLESS_COMPAT_VERSION}/datadog-serverless-compat.zip"
+          unzip ./temp/datadog-serverless-compat.zip -d ./
       - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: bin
           path: bin
   publish:
+    if: ${{ github.event.inputs.publish-package == 'Build and Publish' }}
     runs-on: ubuntu-latest
     needs: [build]
     steps:
@@ -49,6 +56,7 @@ jobs:
       - run: yarn
       - run: yarn npm publish
   release:
+    if: ${{ github.event.inputs.publish-package == 'Build and Publish' }}
     runs-on: ubuntu-latest
     needs: [build, publish]
     permissions:


### PR DESCRIPTION
### What does this PR do?

- Use binaries from serverless-components in package
- Add option to only build (and not publish) package for testing

### Motivation

https://datadoghq.atlassian.net/browse/SVLS-6786

### Additional Notes

### Describe how to test/QA your changes

Installed package created by CI and deployed to Azure Functions
