### PR TITLE
chore: refactor package version and fix serverless-components link in release note

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,7 +85,7 @@ jobs:
     steps:
       - uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # v2.1.0
         with:
-          body: "Uses [${{ env.SERVERLESS_COMPAT_VERSION }}](https://github.com/DataDog/libdatadog/releases/tag/sls-${{ env.SERVERLESS_COMPAT_VERSION }}) of the Serverless Compatibility Layer binary."
+          body: "Uses [${{ env.SERVERLESS_COMPAT_VERSION }}](https://github.com/DataDog/serverless-components/releases/tag/${{ env.SERVERLESS_COMPAT_VERSION }}) of the Serverless Compatibility Layer binary."
           draft: true
           tag_name: "v${{ env.PACKAGE_VERSION }}"
           generate_release_notes: true

--- a/src/index.js
+++ b/src/index.js
@@ -42,20 +42,18 @@ function getBinaryPath() {
     return binaryPath
 }
 
-// Pass package version to binary via environment variable
-function setPackageVersion() {
+function getPackageVersion() {
     let packageVersion
 
     try {
-        const { version } = require('../package.json');
-        packageVersion = version;
+        const { version } = require('../package.json')
+        packageVersion = version
     } catch (err) {
         logger.error(`Unable to identify package version: ${err}`)
-        packageVersion = "unknown";
+        packageVersion = "unknown"
     }
 
-    logger.debug(`Setting DD_SERVERLESS_COMPAT_VERSION to ${packageVersion}`)
-    process.env.DD_SERVERLESS_COMPAT_VERSION = packageVersion
+    return packageVersion
 }
 
 function start() {
@@ -82,10 +80,12 @@ function start() {
         return
     }
 
-    setPackageVersion()
+    const packageVersion = getPackageVersion()
+    logger.debug(`Found package version ${packageVersion}`)
 
     try {
-        childProcess.spawn(binaryPath, { stdio: 'inherit' })
+        const env = { ...process.env, DD_SERVERLESS_COMPAT_VERSION: packageVersion }
+        childProcess.spawn(binaryPath, { stdio: 'inherit', env: env })
     } catch (err) {
         logger.error(err, `An unexpected error occurred while spawning Serverless Compatibility Layer process`)
     }


### PR DESCRIPTION
### What does this PR do?

* rename package version method
* Only set `DD_SERVERLESS_COMPAT_VERSION` environment variable on subprocess
* fix serverless-components link in release note 

### Motivation

* get package version method naming consistency with other Serverless Compatibility Layer packages
* Avoid setting environment variables on main process that aren't needed
* Link correctly to serverless-components repo in release note

### Additional Notes

<!-- Any other relevant context that would be helpful. -->

### Describe how to test/QA your changes

Deployed to Azure Functions, validated that `_dd.serverless_compat_version` attribute is set correctly
