### PR TITLE
fix: copy binary to temp directory and set execute permissions at startup

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,7 @@ function start() {
         fs.mkdirSync(tempDir, { recursive: true });
         const executableFilePath = path.join(tempDir, path.basename(binaryPath));
         fs.copyFileSync(binaryPath, executableFilePath);
-        fs.chmodSync(executableFilePath, 0o755);
+        fs.chmodSync(executableFilePath, 0o744);
         logger.debug(`Spawning process from binary at path ${executableFilePath}`)
 
         const env = { ...process.env, DD_SERVERLESS_COMPAT_VERSION: packageVersion }


### PR DESCRIPTION
### What does this PR do?

Copy `datadog-serverless-compat` binary to a temp directory and set execute permissions at startup.

### Motivation

Depending on the deployment method the execute permissions can be stripped from the binary. This ensures that the binary has execute permissions regardless of the deployment method.

https://datadoghq.atlassian.net/browse/SVLS-6768

### Additional Notes

<!-- Any other relevant context that would be helpful. -->

### Describe how to test/QA your changes

Deployed package to the environments below with binaries stripped of execute permissions and confirmed that the binary still starts and traces are sent to Datadog. ssh'ed into environments where possible to verify file correctly had execute permissions added (Azure Function PremiumV3 environments).

Tested both a fresh install and an upgrade from the latest version to this development version.

- Azure Function / Linux / PremiumV3 ✅ 
- Azure Function / Linux / Consumption ✅ 
- Azure Function / Linux / Flex ✅ 
- Azure Function / Windows / PremiumV3 ✅ 
- Azure Function / Windows / Consumption ✅ 
- Google Cloud Run Function Gen 1 ✅ 
