### PR TITLE
chore: use yarn version to set package version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,17 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - id: package
         run: |
-          PACKAGE_VERSION=$(awk -F '"' '/"version":/ {print $4}' package.json)
+          MODE="${{ github.event.inputs.publish-package }}"
+          if [[ "$MODE" == "Build" ]]; then
+            PACKAGE_VERSION=$(awk -F '"' '/"version":/ {print $4}' package.json)
+          else
+            if [[ ! "$GITHUB_REF" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "Invalid tag format: $GITHUB_REF, must be in the form vMAJOR.MINOR.PATCH"
+              exit 1
+            fi
+            PACKAGE_VERSION="${GITHUB_REF#refs/tags/v}"
+          fi
+
           echo "package-version=$PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
       - id: serverless-compat-binary
         run: |
@@ -43,6 +53,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: [downloadbinaries]
+    env:
+      PACKAGE_VERSION: ${{ needs.downloadbinaries.outputs.package-version }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
@@ -52,6 +64,7 @@ jobs:
       - run: yarn config set npmAuthToken $NPM_PUBLISH_TOKEN
         env:
           NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+      - run: yarn version ${{ env.PACKAGE_VERSION }}
       - run: yarn
       - run: yarn pack
       - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
@@ -80,8 +93,8 @@ jobs:
     permissions:
       contents: write
     env:
-      PACKAGE_VERSION: ${{ needs.build.outputs.package-version }}
-      SERVERLESS_COMPAT_VERSION: ${{ needs.build.outputs.serverless-compat-version }}
+      PACKAGE_VERSION: ${{ needs.downloadbinaries.outputs.package-version }}
+      SERVERLESS_COMPAT_VERSION: ${{ needs.downloadbinaries.outputs.serverless-compat-version }}
     steps:
       - uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # v2.1.0
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,16 +24,11 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - id: package
         run: |
-          MODE="${{ github.event.inputs.publish-package }}"
-          if [[ "$MODE" == "Build" ]]; then
-            PACKAGE_VERSION=$(awk -F '"' '/"version":/ {print $4}' package.json)
-          else
-            if [[ ! "$GITHUB_REF" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo "Invalid tag format: $GITHUB_REF, must be in the form vMAJOR.MINOR.PATCH"
-              exit 1
-            fi
-            PACKAGE_VERSION="${GITHUB_REF#refs/tags/v}"
+          if [[ ! "$GITHUB_REF" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid tag format: $GITHUB_REF, must be in the form vMAJOR.MINOR.PATCH"
+            exit 1
           fi
+          PACKAGE_VERSION="${GITHUB_REF#refs/tags/v}"
 
           echo "package-version=$PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
       - id: serverless-compat-binary
@@ -57,13 +52,12 @@ jobs:
       PACKAGE_VERSION: ${{ needs.downloadbinaries.outputs.package-version }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: "18.x"
-      - run: yarn config set npmAuthToken $NPM_PUBLISH_TOKEN
-        env:
-          NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
       - run: yarn version ${{ env.PACKAGE_VERSION }}
       - run: yarn
       - run: yarn pack
@@ -89,7 +83,7 @@ jobs:
   release:
     if: ${{ github.event.inputs.publish-package == 'Build and Publish' }}
     runs-on: ubuntu-latest
-    needs: [build, publish]
+    needs: [downloadbinaries, build, publish]
     permissions:
       contents: write
     env:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/serverless-compat",
-  "version": "0.4.0",
+  "version": "0.0.0",
   "description": "Datadog Serverless Compatibility Layer to Enable Tracing and Metrics in Node.js",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
### What does this PR do?

Use `yarn version` in Github release workflow to set the version instead of hardcoding the version in `package.json`.

### Motivation

Remove a manual step during the release process.

### Additional Notes

Package version is read from the Git tag used for the release.

### Describe how to test/QA your changes

Tested in a separate repo to avoid the creation of test tags and test releases in this repo.

- Validated that packages created during the build step have a version which matches the tag the Github workflow ran against
- Validated that the workflow stops if the tag does not match the expected format `vMAJOR.MINOR.PATCH`
