### PR TITLE
fix: run yarn version in publish job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,8 +69,12 @@ jobs:
     if: ${{ github.event.inputs.publish-package == 'Build and Publish' }}
     runs-on: ubuntu-latest
     needs: [downloadbinaries]
+    env:
+      PACKAGE_VERSION: ${{ needs.downloadbinaries.outputs.package-version }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
@@ -78,6 +82,7 @@ jobs:
       - run: yarn config set npmAuthToken $NPM_PUBLISH_TOKEN
         env:
           NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+      - run: yarn version ${{ env.PACKAGE_VERSION }}
       - run: yarn
       - run: yarn npm publish
   release:


### PR DESCRIPTION
### What does this PR do?

Run `yarn version` in publish job in addition to build job.

### Motivation

Previously only `yarn version` was run in the build job.

### Additional Notes

Follows https://github.com/DataDog/datadog-serverless-compat-js/pull/18

### Describe how to test/QA your changes

<!-- How was the change validated? Are there automated tests to prevent regressions? -->
