### PR TITLE
fix: use correct path for main entrypoint and add yarn clean command

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,6 +60,7 @@ jobs:
           node-version: "18.x"
       - run: yarn version ${{ env.PACKAGE_VERSION }}
       - run: yarn
+      - run: yarn prebuild
       - run: yarn build
       - run: yarn pack
       - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
@@ -85,6 +86,7 @@ jobs:
           NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
       - run: yarn version ${{ env.PACKAGE_VERSION }}
       - run: yarn
+      - run: yarn prebuild
       - run: yarn build
       - run: yarn npm publish
   release:

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ dist/
 
 # Jest
 coverage
+
+# Dynamically generated version file
+version.ts

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -6,6 +6,7 @@ dev,@types/node,https://github.com/DefinitelyTyped/DefinitelyTyped,MIT,Copyright
 dev,eslint,https://github.com/eslint/eslint,MIT,"Copyright OpenJS Foundation and other contributors, <www.openjsf.org>"
 dev,globals,https://github.com/sindresorhus/globals,MIT,Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
 dev,jest,https://github.com/jestjs/jest,MIT,"Copyright (c) Meta Platforms, Inc. and affiliates.Copyright Contributors to the Jest project."
+dev,rimraf,https://github.com/isaacs/rimraf,ISC,Copyright (c) 2011-2023 Isaac Z. Schlueter and Contributors
 dev,ts-jest,https://github.com/kulshekhar/ts-jest,MIT,Copyright (c) 2016-2025
 dev,ts-node,https://github.com/TypeStrong/ts-node,MIT,Copyright (c) 2014 Blake Embrey (hello@blakeembrey.com)
 dev,typescript,https://github.com/microsoft/TypeScript,Apache-2.0,Copyright (c) Microsoft Corporation

--- a/package.json
+++ b/package.json
@@ -2,10 +2,11 @@
   "name": "@datadog/serverless-compat",
   "version": "0.0.0",
   "description": "Datadog Serverless Compatibility Layer to Enable Tracing and Metrics in Node.js",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
   "scripts": {
     "build": "tsc",
+    "clean": "rimraf dist",
     "lint": "node scripts/check_licenses.js && yarn run eslint . && yarn npm audit",
     "test": "jest"
   },
@@ -42,6 +43,7 @@
     "eslint": "^9.16.0",
     "globals": "^15.13.0",
     "jest": "^30.0.5",
+    "rimraf": "^6.0.1",
     "ts-jest": "^29.4.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.2"

--- a/package.json
+++ b/package.json
@@ -2,12 +2,13 @@
   "name": "@datadog/serverless-compat",
   "version": "0.0.0",
   "description": "Datadog Serverless Compatibility Layer to Enable Tracing and Metrics in Node.js",
-  "main": "dist/src/index.js",
-  "types": "dist/src/index.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
     "clean": "rimraf dist",
     "lint": "node scripts/check_licenses.js && yarn run eslint . && yarn npm audit",
+    "prebuild": "node -p \"'export const LIB_VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > src/version.ts",
     "test": "jest"
   },
   "repository": "github.com/DataDog/datadog-serverless-compat-js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, copyFileSync, chmodSync } from 'fs';
 import { tmpdir } from 'os';
 import { resolve, join, basename } from 'path';
 import defaultLogger, { Logger } from './utils/log';
-import { version as packageVersion } from '../package.json';
+import { LIB_VERSION as packageVersion } from './version';
 
 enum CloudEnvironment {
   AZURE_FUNCTION = 'Azure Function',

--- a/yarn.lock
+++ b/yarn.lock
@@ -411,6 +411,7 @@ __metadata:
     eslint: "npm:^9.16.0"
     globals: "npm:^15.13.0"
     jest: "npm:^30.0.5"
+    rimraf: "npm:^6.0.1"
     ts-jest: "npm:^29.4.1"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.9.2"
@@ -566,6 +567,22 @@ __metadata:
   version: 0.4.3
   resolution: "@humanwhocodes/retry@npm:0.4.3"
   checksum: 10c0/3775bb30087d4440b3f7406d5a057777d90e4b9f435af488a4923ef249e93615fb78565a85f173a186a076c7706a81d0d57d563a2624e4de2c5c9c66c486ce42
+  languageName: node
+  linkType: hard
+
+"@isaacs/balanced-match@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@isaacs/balanced-match@npm:4.0.1"
+  checksum: 10c0/7da011805b259ec5c955f01cee903da72ad97c5e6f01ca96197267d3f33103d5b2f8a1af192140f3aa64526c593c8d098ae366c2b11f7f17645d12387c2fd420
+  languageName: node
+  linkType: hard
+
+"@isaacs/brace-expansion@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "@isaacs/brace-expansion@npm:5.0.0"
+  dependencies:
+    "@isaacs/balanced-match": "npm:^4.0.1"
+  checksum: 10c0/b4d4812f4be53afc2c5b6c545001ff7a4659af68d4484804e9d514e183d20269bb81def8682c01a22b17c4d6aed14292c8494f7d2ac664e547101c1a905aa977
   languageName: node
   linkType: hard
 
@@ -2147,7 +2164,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"foreground-child@npm:^3.1.0":
+"foreground-child@npm:^3.1.0, foreground-child@npm:^3.3.1":
   version: 3.3.1
   resolution: "foreground-child@npm:3.3.1"
   dependencies:
@@ -2242,6 +2259,22 @@ __metadata:
   bin:
     glob: dist/esm/bin.mjs
   checksum: 10c0/19a9759ea77b8e3ca0a43c2f07ecddc2ad46216b786bb8f993c445aee80d345925a21e5280c7b7c6c59e860a0154b84e4b2b60321fea92cd3c56b4a7489f160e
+  languageName: node
+  linkType: hard
+
+"glob@npm:^11.0.0":
+  version: 11.0.3
+  resolution: "glob@npm:11.0.3"
+  dependencies:
+    foreground-child: "npm:^3.3.1"
+    jackspeak: "npm:^4.1.1"
+    minimatch: "npm:^10.0.3"
+    minipass: "npm:^7.1.2"
+    package-json-from-dist: "npm:^1.0.0"
+    path-scurry: "npm:^2.0.0"
+  bin:
+    glob: dist/esm/bin.mjs
+  checksum: 10c0/7d24457549ec2903920dfa3d8e76850e7c02aa709122f0164b240c712f5455c0b457e6f2a1eee39344c6148e39895be8094ae8cfef7ccc3296ed30bce250c661
   languageName: node
   linkType: hard
 
@@ -2542,6 +2575,15 @@ __metadata:
     "@pkgjs/parseargs":
       optional: true
   checksum: 10c0/6acc10d139eaefdbe04d2f679e6191b3abf073f111edf10b1de5302c97ec93fffeb2fdd8681ed17f16268aa9dd4f8c588ed9d1d3bffbbfa6e8bf897cbb3149b9
+  languageName: node
+  linkType: hard
+
+"jackspeak@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "jackspeak@npm:4.1.1"
+  dependencies:
+    "@isaacs/cliui": "npm:^8.0.2"
+  checksum: 10c0/84ec4f8e21d6514db24737d9caf65361511f75e5e424980eebca4199f400874f45e562ac20fa8aeb1dd20ca2f3f81f0788b6e9c3e64d216a5794fd6f30e0e042
   languageName: node
   linkType: hard
 
@@ -3131,6 +3173,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lru-cache@npm:^11.0.0":
+  version: 11.1.0
+  resolution: "lru-cache@npm:11.1.0"
+  checksum: 10c0/85c312f7113f65fae6a62de7985348649937eb34fb3d212811acbf6704dc322a421788aca253b62838f1f07049a84cc513d88f494e373d3756514ad263670a64
+  languageName: node
+  linkType: hard
+
 "lru-cache@npm:^5.1.1":
   version: 5.1.1
   resolution: "lru-cache@npm:5.1.1"
@@ -3205,6 +3254,15 @@ __metadata:
   version: 2.1.0
   resolution: "mimic-fn@npm:2.1.0"
   checksum: 10c0/b26f5479d7ec6cc2bce275a08f146cf78f5e7b661b18114e2506dd91ec7ec47e7a25bf4360e5438094db0560bcc868079fb3b1fb3892b833c1ecbf63f80c95a4
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^10.0.3":
+  version: 10.0.3
+  resolution: "minimatch@npm:10.0.3"
+  dependencies:
+    "@isaacs/brace-expansion": "npm:^5.0.0"
+  checksum: 10c0/e43e4a905c5d70ac4cec8530ceaeccb9c544b1ba8ac45238e2a78121a01c17ff0c373346472d221872563204eabe929ad02669bb575cb1f0cc30facab369f70f
   languageName: node
   linkType: hard
 
@@ -3557,6 +3615,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-scurry@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "path-scurry@npm:2.0.0"
+  dependencies:
+    lru-cache: "npm:^11.0.0"
+    minipass: "npm:^7.1.2"
+  checksum: 10c0/3da4adedaa8e7ef8d6dc4f35a0ff8f05a9b4d8365f2b28047752b62d4c1ad73eec21e37b1579ef2d075920157856a3b52ae8309c480a6f1a8bbe06ff8e52b33c
+  languageName: node
+  linkType: hard
+
 "picocolors@npm:^1.1.1":
   version: 1.1.1
   resolution: "picocolors@npm:1.1.1"
@@ -3684,6 +3752,18 @@ __metadata:
   version: 0.12.0
   resolution: "retry@npm:0.12.0"
   checksum: 10c0/59933e8501727ba13ad73ef4a04d5280b3717fd650408460c987392efe9d7be2040778ed8ebe933c5cbd63da3dcc37919c141ef8af0a54a6e4fca5a2af177bfe
+  languageName: node
+  linkType: hard
+
+"rimraf@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "rimraf@npm:6.0.1"
+  dependencies:
+    glob: "npm:^11.0.0"
+    package-json-from-dist: "npm:^1.0.0"
+  bin:
+    rimraf: dist/esm/bin.mjs
+  checksum: 10c0/b30b6b072771f0d1e73b4ca5f37bb2944ee09375be9db5f558fcd3310000d29dfcfa93cf7734d75295ad5a7486dc8e40f63089ced1722a664539ffc0c3ece8c6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What does this PR do?

Adds a `yarn prebuild` script to create a `version.ts` file which copies the version from `package.json` to a `verstion.ts` file at build time instead of importing it at runtime.

### Motivation

Because `package.json` is being imported in `src/index.js` the entire `src` directory is copied into `dist` in addition to `package.json` when the typescript files are compiled. However `main` and `types` are configured to look in `dist` (not `dist/src`) for `index.js` and `index.d.ts`.

https://github.com/DataDog/datadog-serverless-compat-js/blob/1072c7b00672aaa314742189e6feaae02b04571e/src/index.ts#L6

```
dist/
├── src/
│   ├── index.js
│   └── index.d.ts
└── package.json
```

With the current settings there is an error when importing the library.

```
Cannot find module '@datadog/serverless-compat' or its corresponding type declarations.
```

### Additional Notes

While testing locally there were old files compiled into the root of the `dist` directory that made it appear the original settings for `main` and `types` in `package.json` were correct. Added a `yarn clean` command to help prevent this type of error in the future.

### Describe how to test/QA your changes

Ran `yarn clean` to delete `dist` directory and rebuild project with a freshly compiled directory. Deployed Node Azure Functions with this package and verified traces and metrics are sent successfully.
