### PR TITLE
[CHORE] ignore package.tgz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ node_modules
 !.yarn/sdks
 !.yarn/versions
 
+# Package build output
+*.tgz
+
 # TypeScript compiled output
 dist/
 


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

To support local builds, we should ignore the output of running the build:
```sh
yarn && yarn prebuild && yarn build && yarn pack
```

^this produces a package.tgz file, which we can gitignore

### Motivation

Improving the developer workflow for testing

### Additional Notes

<!-- Any other relevant context that would be helpful. -->

### Describe how to test/QA your changes

<!-- How was the change validated? Are there automated tests to prevent regressions? -->
