### PR TITLE
Add log format with level, logger name, location

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,10 @@ import { spawn } from 'child_process';
 import { existsSync, mkdirSync, copyFileSync, chmodSync } from 'fs';
 import { tmpdir } from 'os';
 import { resolve, join, basename } from 'path';
-import defaultLogger, { Logger } from './utils/log';
+import { logger, Logger } from './utils/log';
 import { LIB_VERSION as packageVersion } from './version';
+
+const defaultLogger = logger(__filename);
 
 enum CloudEnvironment {
   AZURE_FUNCTION = 'Azure Function',

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -1,5 +1,7 @@
 /* eslint-disable no-console */
 
+import { sep, join } from 'path';
+
 export interface Logger {
   debug: (message: string) => void;
   info: (message: string) => void;
@@ -9,6 +11,18 @@ export interface Logger {
 
 const DD_LOG_LEVEL = process.env.DD_LOG_LEVEL;
 const LOGGER_NAME = 'datadog-serverless-compat';
+
+// Limit the stack trace for performance by default. We're only interested in where log is called, not the whole trace.
+let STACK_TRACE_LIMIT = 5;
+
+/**
+ * Set the stack trace limit for log location tracking.
+ * Lower values improve performance but may miss the caller in deep call stacks.
+ * @param limit - Maximum number of stack frames to capture (default: 5)
+ */
+export function setStackTraceLimit(limit: number): void {
+  STACK_TRACE_LIMIT = limit;
+}
 
 const logLevels: Record<string, number> = {
   trace: 20,
@@ -22,46 +36,73 @@ const logLevels: Record<string, number> = {
 
 const levelKey = (DD_LOG_LEVEL || 'info').toLowerCase();
 const logLevel: number = logLevels[levelKey] ?? logLevels.info;
+const defaultLocation = 'unknown:0';
+
 
 /**
- * Get the function caller's file location (filename:line) using V8's CallSite API
+ * Get the log function caller's file location (filename:line)
  * @returns formatted string like "filename.ts:42"
  */
 function getCallerInfo(): string {
   // Temporarily configure V8's Error.prepareStackTrace to return CallSite objects
   // CallSite API: https://v8.dev/docs/stack-trace-api
   const originalPrepareStackTrace = Error.prepareStackTrace;
+  const originalStackTraceLimit = Error.stackTraceLimit;
 
   try {
     Error.prepareStackTrace = (_err: Error, stack: NodeJS.CallSite[]) => stack;
+    Error.stackTraceLimit = STACK_TRACE_LIMIT;
 
     const obj: { stack?: NodeJS.CallSite[] } = {};
     Error.captureStackTrace(obj);
     const stack = obj.stack;
 
-    if (!stack || stack.length < 3) {
-      return 'unknown:0';
+    if (!stack) {
+      return defaultLocation;
     }
 
     // Find the first call site outside of log.ts
     for (let i = 1; i < stack.length; i++) {
       const callSite = stack[i];
-      const fileName = callSite.getFileName();
-      if (fileName && !fileName.includes('log.ts') && !fileName.includes('log.js')) {
-        const lineNumber = callSite.getLineNumber();
-        if (lineNumber) {
-          const filename = fileName.split('/').pop() || fileName;
-          return `${filename}:${lineNumber}`;
+      let fileName = callSite.getFileName();
+      let lineNumber = callSite.getLineNumber();
+
+      // Handle eval contexts by using getEvalOrigin
+      if (!fileName && callSite.isEval()) {
+        const evalOrigin = callSite.getEvalOrigin();
+        if (evalOrigin) {
+          // Parse the eval origin to extract the file location
+          // Example formats:
+          // "eval at Foo.a (myscript.js:10:3)"
+          // "eval at Foo.a (eval at Bar.z (myscript.js:10:3))"
+          // For nested evals, we want the innermost (last) file location
+          const fileMatches = Array.from(evalOrigin.matchAll(/([^/\\()\s:]+):(\d+):\d+/g));
+          const lastMatch = fileMatches[fileMatches.length - 1];
+          if (lastMatch) {
+            fileName = fileName || lastMatch[1];
+            lineNumber = lineNumber || parseInt(lastMatch[2]);
+          }
         }
+      }
+
+      // Skip if no filename and skip the logger file itself. Package is serverless-compat, repo is datadog-serverless-compat-js.
+      if (!fileName || fileName.endsWith(join(sep, 'serverless-compat', 'src', 'utils', 'log.ts')) || fileName.endsWith(join(sep, 'datadog-serverless-compat-js', 'src', 'utils', 'log.ts'))) {
+        continue;
+      }
+
+      if (fileName && lineNumber) {
+        const filename = fileName.split(sep).pop() || fileName;
+        return `${filename}:${lineNumber}`;
       }
     }
 
-    return 'unknown:0';
+    return defaultLocation;
   } catch (err) {
-    return 'unknown:0';
+    return defaultLocation;
   } finally {
     // Restore the original prepareStackTrace to avoid side effects
     Error.prepareStackTrace = originalPrepareStackTrace;
+    Error.stackTraceLimit = originalStackTraceLimit;
   }
 }
 
@@ -74,7 +115,6 @@ function formatLog(level: string, message: string): string {
   return `${level} [${LOGGER_NAME}] [${location}] - ${message}`;
 }
 
-
 export const log: Logger = {
   debug:
     logLevel <= 20
@@ -83,10 +123,17 @@ export const log: Logger = {
   info: logLevel <= 30 ? (msg: string) => console.info(formatLog('INFO', msg)) : () => { },
   warn: logLevel <= 40 ? (msg: string) => console.warn(formatLog('WARN', msg)) : () => { },
   error:
-    logLevel <= 50 
+    logLevel <= 50
       ? (err: string | Error) => {
-          const message = err instanceof Error ? err.message : err;
-          console.error(formatLog('ERROR', message));
+          if (err instanceof Error) {
+            const formatted = formatLog('ERROR', err.message);
+            // Log with the formatted message and original stack, but avoid mutating the original error.
+            const formattedError = new Error(formatted);
+            formattedError.stack = err.stack;
+            console.error(formattedError);
+          } else {
+            console.error(formatLog('ERROR', err));
+          }
         }
       : () => { },
 };

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -63,10 +63,14 @@ export function logger(callSite: string): Logger {
         ? (err: string | Error) => {
             if (err instanceof Error) {
               const formatted = formatLog('ERROR', location, err.message);
-              // Log with the formatted message and original stack, but avoid mutating the original error.
-              const formattedError = new Error(formatted);
-              formattedError.stack = err.stack;
-              console.error(formattedError);
+              // Preserve the stack trace but replace the first line with our formatted message
+              if (err.stack) {
+                const stackLines = err.stack.split('\n');
+                stackLines[0] = formatted; // Replace "Error: message" with formatted message
+                console.error(stackLines.join('\n'));
+              } else {
+                console.error(formatted);
+              }
             } else {
               console.error(formatLog('ERROR', location, err));
             }

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 
-import { sep, join } from 'path';
+import { sep } from 'path';
 
 export interface Logger {
   debug: (message: string) => void;
@@ -11,18 +11,6 @@ export interface Logger {
 
 const DD_LOG_LEVEL = process.env.DD_LOG_LEVEL;
 const LOGGER_NAME = 'datadog-serverless-compat';
-
-// Limit the stack trace for performance by default. We're only interested in where log is called, not the whole trace.
-let STACK_TRACE_LIMIT = 5;
-
-/**
- * Set the stack trace limit for log location tracking.
- * Lower values improve performance but may miss the caller in deep call stacks.
- * @param limit - Maximum number of stack frames to capture (default: 5)
- */
-export function setStackTraceLimit(limit: number): void {
-  STACK_TRACE_LIMIT = limit;
-}
 
 const logLevels: Record<string, number> = {
   trace: 20,
@@ -36,106 +24,53 @@ const logLevels: Record<string, number> = {
 
 const levelKey = (DD_LOG_LEVEL || 'info').toLowerCase();
 const logLevel: number = logLevels[levelKey] ?? logLevels.info;
-const defaultLocation = 'unknown:0';
-
 
 /**
- * Get the log function caller's file location (filename:line)
- * @returns formatted string like "filename.ts:42"
+ * Format the log with level, name of the serverless package, and call site location
+ * Format: LEVEL [name] [location] - message
  */
-function getCallerInfo(): string {
-  // Temporarily configure V8's Error.prepareStackTrace to return CallSite objects
-  // CallSite API: https://v8.dev/docs/stack-trace-api
-  const originalPrepareStackTrace = Error.prepareStackTrace;
-  const originalStackTraceLimit = Error.stackTraceLimit;
-
-  try {
-    Error.prepareStackTrace = (_err: Error, stack: NodeJS.CallSite[]) => stack;
-    Error.stackTraceLimit = STACK_TRACE_LIMIT;
-
-    const obj: { stack?: NodeJS.CallSite[] } = {};
-    Error.captureStackTrace(obj);
-    const stack = obj.stack;
-
-    if (!stack) {
-      return defaultLocation;
-    }
-
-    // Find the first call site outside of log.ts
-    for (let i = 1; i < stack.length; i++) {
-      const callSite = stack[i];
-      let fileName = callSite.getFileName();
-      let lineNumber = callSite.getLineNumber();
-
-      // Handle eval contexts by using getEvalOrigin
-      if (!fileName && callSite.isEval()) {
-        const evalOrigin = callSite.getEvalOrigin();
-        if (evalOrigin) {
-          // Parse the eval origin to extract the file location
-          // Example formats:
-          // "eval at Foo.a (myscript.js:10:3)"
-          // "eval at Foo.a (eval at Bar.z (myscript.js:10:3))"
-          // For nested evals, we want the innermost (last) file location
-          const fileMatches = Array.from(evalOrigin.matchAll(/([^/\\()\s:]+):(\d+):\d+/g));
-          const lastMatch = fileMatches[fileMatches.length - 1];
-          if (lastMatch) {
-            fileName = fileName || lastMatch[1];
-            lineNumber = lineNumber || parseInt(lastMatch[2]);
-          }
-        }
-      }
-
-      // Skip if no filename and skip the logger file itself. Package is serverless-compat, repo is datadog-serverless-compat-js.
-      if (!fileName || /serverless-compat[^/\\]*[/\\].*[/\\]utils[/\\]log\.(ts|js)$/.test(fileName)) {  
-        continue;
-      }
-
-      if (fileName && lineNumber) {
-        const filename = fileName.split(sep).pop() || fileName;
-        return `${filename}:${lineNumber}`;
-      }
-    }
-
-    return defaultLocation;
-  } catch (err) {
-    return defaultLocation;
-  } finally {
-    // Restore the original prepareStackTrace to avoid side effects
-    Error.prepareStackTrace = originalPrepareStackTrace;
-    Error.stackTraceLimit = originalStackTraceLimit;
-  }
-}
-
-/**
- * Format the log with level, name of the serverless package formatting the log, and line number
- * Format: LEVEL [name] [filename:line] - message
- */
-function formatLog(level: string, message: string): string {
-  const location = getCallerInfo();
+function formatLog(level: string, location: string, message: string): string {
   return `${level} [${LOGGER_NAME}] [${location}] - ${message}`;
 }
 
-export const log: Logger = {
-  debug:
-    logLevel <= 20
-      ? (msg: string) => (console.debug || console.log)(formatLog('DEBUG', msg))
-      : () => { },
-  info: logLevel <= 30 ? (msg: string) => console.info(formatLog('INFO', msg)) : () => { },
-  warn: logLevel <= 40 ? (msg: string) => console.warn(formatLog('WARN', msg)) : () => { },
-  error:
-    logLevel <= 50
-      ? (err: string | Error) => {
-          if (err instanceof Error) {
-            const formatted = formatLog('ERROR', err.message);
-            // Log with the formatted message and original stack, but avoid mutating the original error.
-            const formattedError = new Error(formatted);
-            formattedError.stack = err.stack;
-            console.error(formattedError);
-          } else {
-            console.error(formatLog('ERROR', err));
-          }
-        }
-      : () => { },
-};
+/**
+ * Create a logger instance with a specific call site name.
+ * The call site name is typically the filename (e.g., __filename) to provide caller context.
+ * 
+ * @param callSite - The name or path of the file creating the logger (e.g., __filename)
+ * @returns A Logger instance configured for the specified call site
+ * 
+ * @example
+ * ```typescript
+ * import { logger } from './utils/log';
+ * const log = logger(__filename);
+ * log.info('Starting process');
+ * ```
+ */
+export function logger(callSite: string): Logger {
+  // Extract just the filename from the full path
+  const location = callSite.split(sep).pop() || callSite;
 
-export default log;
+  return {
+    debug:
+      logLevel <= 20
+        ? (msg: string) => (console.debug || console.log)(formatLog('DEBUG', location, msg))
+        : () => { },
+    info: logLevel <= 30 ? (msg: string) => console.info(formatLog('INFO', location, msg)) : () => { },
+    warn: logLevel <= 40 ? (msg: string) => console.warn(formatLog('WARN', location, msg)) : () => { },
+    error:
+      logLevel <= 50
+        ? (err: string | Error) => {
+            if (err instanceof Error) {
+              const formatted = formatLog('ERROR', location, err.message);
+              // Log with the formatted message and original stack, but avoid mutating the original error.
+              const formattedError = new Error(formatted);
+              formattedError.stack = err.stack;
+              console.error(formattedError);
+            } else {
+              console.error(formatLog('ERROR', location, err));
+            }
+          }
+        : () => { },
+  };
+}

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -86,7 +86,7 @@ function getCallerInfo(): string {
       }
 
       // Skip if no filename and skip the logger file itself. Package is serverless-compat, repo is datadog-serverless-compat-js.
-      if (!fileName || fileName.endsWith(join(sep, 'serverless-compat', 'src', 'utils', 'log.ts')) || fileName.endsWith(join(sep, 'datadog-serverless-compat-js', 'src', 'utils', 'log.ts'))) {
+      if (!fileName || /serverless-compat[^/\\]*[/\\].*[/\\]utils[/\\]log\.(ts|js)$/.test(fileName)) {  
         continue;
       }
 

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -8,6 +8,7 @@ export interface Logger {
 }
 
 const DD_LOG_LEVEL = process.env.DD_LOG_LEVEL;
+const LOGGER_NAME = 'datadog-serverless-compat';
 
 const logLevels: Record<string, number> = {
   trace: 20,
@@ -22,15 +23,72 @@ const logLevels: Record<string, number> = {
 const levelKey = (DD_LOG_LEVEL || 'info').toLowerCase();
 const logLevel: number = logLevels[levelKey] ?? logLevels.info;
 
+/**
+ * Get the function caller's file location (filename:line) using V8's CallSite API
+ * @returns formatted string like "filename.ts:42"
+ */
+function getCallerInfo(): string {
+  // Temporarily configure V8's Error.prepareStackTrace to return CallSite objects
+  // CallSite API: https://v8.dev/docs/stack-trace-api
+  const originalPrepareStackTrace = Error.prepareStackTrace;
+
+  try {
+    Error.prepareStackTrace = (_err: Error, stack: NodeJS.CallSite[]) => stack;
+
+    const obj: { stack?: NodeJS.CallSite[] } = {};
+    Error.captureStackTrace(obj);
+    const stack = obj.stack;
+
+    if (!stack || stack.length < 3) {
+      return 'unknown:0';
+    }
+
+    // Find the first call site outside of log.ts
+    for (let i = 1; i < stack.length; i++) {
+      const callSite = stack[i];
+      const fileName = callSite.getFileName();
+      if (fileName && !fileName.includes('log.ts') && !fileName.includes('log.js')) {
+        const lineNumber = callSite.getLineNumber();
+        if (lineNumber) {
+          const filename = fileName.split('/').pop() || fileName;
+          return `${filename}:${lineNumber}`;
+        }
+      }
+    }
+
+    return 'unknown:0';
+  } catch (err) {
+    return 'unknown:0';
+  } finally {
+    // Restore the original prepareStackTrace to avoid side effects
+    Error.prepareStackTrace = originalPrepareStackTrace;
+  }
+}
+
+/**
+ * Format the log with level, name of the serverless package formatting the log, and line number
+ * Format: LEVEL [name] [filename:line] - message
+ */
+function formatLog(level: string, message: string): string {
+  const location = getCallerInfo();
+  return `${level} [${LOGGER_NAME}] [${location}] - ${message}`;
+}
+
+
 export const log: Logger = {
   debug:
     logLevel <= 20
-      ? (msg: string) => (console.debug || console.log)(msg)
+      ? (msg: string) => (console.debug || console.log)(formatLog('DEBUG', msg))
       : () => { },
-  info: logLevel <= 30 ? (msg: string) => console.info(msg) : () => { },
-  warn: logLevel <= 40 ? (msg: string) => console.warn(msg) : () => { },
+  info: logLevel <= 30 ? (msg: string) => console.info(formatLog('INFO', msg)) : () => { },
+  warn: logLevel <= 40 ? (msg: string) => console.warn(formatLog('WARN', msg)) : () => { },
   error:
-    logLevel <= 50 ? (err: string | Error) => console.error(err) : () => { },
+    logLevel <= 50 
+      ? (err: string | Error) => {
+          const message = err instanceof Error ? err.message : err;
+          console.error(formatLog('ERROR', message));
+        }
+      : () => { },
 };
 
 export default log;


### PR DESCRIPTION
### What does this PR do?

* Log messages now display in the format: `LEVEL ['datadog-serverless-compat] [filename] - message`
* New unit tests for the logging formatter

### Motivation

* Improve observability and debugging by providing structured logging
* Consistency with structured logging in other compatibility layers [ex: logger.py](https://github.com/DataDog/datadog-serverless-compat-py/blob/main/datadog_serverless_compat/logger.py)
* Handles normal and eval callsites, similarly to [dd-trace-js](https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/util/stacktrace.js), but with attention to the log callsite instead of the whole stack trace. 

### Describe how to test/QA your changes

- [x] Unit tests are passing
- [x] Test for azure functions
- [ ] Test for gcrfx gen 1 (optional)

<img width="1000" height="135" alt="Screenshot 2025-12-09 at 11 31 39 AM" src="https://github.com/user-attachments/assets/8ac60a36-fbb9-4819-81d4-bd85a181863d" />