### PR TITLE
fix: remove npm publish token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,9 +92,6 @@ jobs:
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: "18.x"
-      - run: yarn config set npmAuthToken $NPM_PUBLISH_TOKEN
-        env:
-          NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
       - run: yarn version ${{ env.PACKAGE_VERSION }}
       - run: yarn
       - run: yarn prebuild


### PR DESCRIPTION
### What does this PR do?

Remove references to NPM Publish Token in publish Github Workflow.

### Motivation

Following the move to trusted publishing we are no longer using an NPM Publish Token.

https://github.com/DataDog/datadog-serverless-compat-js/pull/26

### Additional Notes

<!-- Any other relevant context that would be helpful. -->

### Describe how to test/QA your changes

<!-- How was the change validated? Are there automated tests to prevent regressions? -->
