### PR TITLE
feat: allow preloading of module

### DIFF
--- a/init.js
+++ b/init.js
@@ -1,0 +1,1 @@
+require('./dist/init.js');

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "files": [
     "dist/**/*",
     "bin/**/*",
+    "init.js",
     "LICENSE-3rdparty.csv",
     "NOTICE"
   ],

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,0 +1,3 @@
+import { start } from './index';
+
+start();


### PR DESCRIPTION
### What does this PR do?

Allows preloading of module with `--require @datadog/serverless-compat/init`.

### Motivation

https://datadoghq.atlassian.net/browse/SVLS-5256

### Additional Notes

Public docs update: https://github.com/DataDog/documentation/pull/34685

### Describe how to test/QA your changes

Set the Node options using the setting below and deploy to Azure Functions.

```
languageWorkers__node__arguments: '--require=/@datadog/serverless-compat/init --require=dd-trace/init'
```
