### PR TITLE
feat: ship platform-specific binaries via optional packages and add support for AWS

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,105 +11,82 @@ on:
         options:
           - "Build"
           - "Build and Publish"
-      package-version-override:
-        description: "Package version override (optional, x.y.z)"
+      package-version:
+        description: "Package version override (x.y.z) — defaults to the latest published version of the platform-specific packages"
         required: false
         type: string
-        default: ""
 
 permissions: {}
 
 jobs:
-  downloadbinaries:
+  resolve-version:
     runs-on: ubuntu-latest
     outputs:
-      package-version: ${{ steps.package.outputs.package-version }}
-      serverless-compat-version: ${{ steps.serverless-compat-binary.outputs.serverless-compat-version }}
+      version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - id: package
+      - name: Resolve package version
+        id: version
+        env:
+          INPUT_VERSION: ${{ inputs.package-version }}
         run: |
-          if [[ -n "${{ github.event.inputs.package-version-override }}" ]]; then
-            PACKAGE_VERSION="${{ github.event.inputs.package-version-override }}"
+          if [ -n "$INPUT_VERSION" ]; then
+            VERSION="$INPUT_VERSION"
           else
-            if [[ ! "$GITHUB_REF" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+(-.+)?$ ]]; then
-              echo "Invalid tag format: $GITHUB_REF, must be in the form vMAJOR.MINOR.PATCH"
-              exit 1
-            fi
-            PACKAGE_VERSION="${GITHUB_REF#refs/tags/v}"
+            VERSION=$(npm view @datadog/serverless-compat-linux-x64 version)
           fi
+          echo "Resolved version: $VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-          echo "package-version=$PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
-      - id: serverless-compat-binary
-        run: |
-          RESPONSE=$(curl -s "https://api.github.com/repos/datadog/serverless-components/releases")
-          SERVERLESS_COMPAT_VERSION=$(echo "$RESPONSE" | jq -r --arg pattern "datadog-serverless-compat\/v[0-9]*\.[0-9]*\.[0-9]*" '.[] | select(.tag_name | test($pattern)) | .tag_name' | sort -V | tail -n 1)
-
-          echo "Using version ${SERVERLESS_COMPAT_VERSION} of Serverless Compatibility Layer binary"
-          echo "serverless-compat-version=$(echo "$SERVERLESS_COMPAT_VERSION" | jq -rR 'ltrimstr("sls-")')" >> "$GITHUB_OUTPUT"
-
-          curl --output-dir ./temp/ --create-dirs -O -s -L "https://github.com/DataDog/serverless-components/releases/download/${SERVERLESS_COMPAT_VERSION}/datadog-serverless-compat.zip"
-          unzip ./temp/datadog-serverless-compat.zip -d ./
-      - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        with:
-          name: bin
-          path: bin
   build:
     runs-on: ubuntu-latest
-    needs: [downloadbinaries]
+    needs: [resolve-version]
     env:
-      PACKAGE_VERSION: ${{ needs.downloadbinaries.outputs.package-version }}
+      PACKAGE_VERSION: ${{ needs.resolve-version.outputs.version }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: "18.x"
-      - run: yarn version ${{ env.PACKAGE_VERSION }}
+      - run: yarn version $PACKAGE_VERSION
+      - name: Update optionalDependencies to match package version
+        run: yarn update-optional-deps "$PACKAGE_VERSION"
       - run: yarn
       - run: yarn prebuild
       - run: yarn build
       - run: yarn pack
-      - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: package
           path: package.tgz
+
   publish:
     if: ${{ github.event.inputs.publish-package == 'Build and Publish' }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-    needs: [downloadbinaries]
-    env:
-      PACKAGE_VERSION: ${{ needs.downloadbinaries.outputs.package-version }}
+    needs: [build]
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          fetch-depth: 0
-      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+          name: package
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: "18.x"
-      - run: yarn version ${{ env.PACKAGE_VERSION }}
-      - run: yarn
-      - run: yarn prebuild
-      - run: yarn build
-      - run: yarn npm publish
+      - run: npm publish package.tgz
+
   release:
     if: ${{ github.event.inputs.publish-package == 'Build and Publish' }}
     runs-on: ubuntu-latest
-    needs: [downloadbinaries, build, publish]
+    needs: [resolve-version, publish]
     permissions:
       contents: write
     env:
-      PACKAGE_VERSION: ${{ needs.downloadbinaries.outputs.package-version }}
-      SERVERLESS_COMPAT_VERSION: ${{ needs.downloadbinaries.outputs.serverless-compat-version }}
+      PACKAGE_VERSION: ${{ needs.resolve-version.outputs.version }}
     steps:
       - uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # v2.1.0
         with:
-          body: "Uses [${{ env.SERVERLESS_COMPAT_VERSION }}](https://github.com/DataDog/serverless-components/releases/tag/${{ env.SERVERLESS_COMPAT_VERSION }}) of the Serverless Compatibility Layer binary."
           draft: true
           tag_name: "v${{ env.PACKAGE_VERSION }}"
           generate_release_notes: true

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "build": "tsc",
     "clean": "rimraf dist",
     "lint": "node scripts/check_licenses.js && yarn run eslint . && yarn npm audit",
-    "prebuild": "node -p \"'export const LIB_VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > src/version.ts",
+    "pack-local": "yarn build && yarn pack",
+    "prebuild": "node scripts/generate-version.js",
+    "update-optional-deps": "node scripts/update-optional-deps.js",
     "test": "jest"
   },
   "repository": "github.com/DataDog/datadog-serverless-compat-js",
@@ -21,17 +23,17 @@
   "packageManager": "yarn@4.12.0",
   "files": [
     "dist/**/*",
-    "bin/**/*",
     "init.js",
     "LICENSE-3rdparty.csv",
     "NOTICE"
   ],
+  "optionalDependencies": {
+    "@datadog/serverless-compat-linux-x64": "0.0.0",
+    "@datadog/serverless-compat-linux-arm64": "0.0.0",
+    "@datadog/serverless-compat-win32-x64": "0.0.0"
+  },
   "publishConfig": {
-    "access": "public",
-    "executableFiles": [
-      "./bin/linux-amd64/datadog-serverless-compat",
-      "./bin/windows-amd64/datadog-serverless-compat.exe"
-    ]
+    "access": "public"
   },
   "bugs": {
     "url": "https://github.com/DataDog/datadog-serverless-compat-js/issues"

--- a/scripts/generate-version.js
+++ b/scripts/generate-version.js
@@ -1,0 +1,13 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-Present Datadog, Inc.
+
+'use strict';
+
+const { writeFileSync } = require('fs');
+const { join } = require('path');
+
+const version = require('../package.json').version;
+const content = `export const LIB_VERSION = ${JSON.stringify(version)};\n`;
+writeFileSync(join(__dirname, '..', 'src', 'version.ts'), content);

--- a/scripts/update-optional-deps.js
+++ b/scripts/update-optional-deps.js
@@ -1,0 +1,28 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-Present Datadog, Inc.
+
+'use strict';
+
+// Usage: node scripts/update-optional-deps.js <version>
+// Updates all optionalDependencies in package.json to the given version.
+
+const { readFileSync, writeFileSync } = require('fs');
+const { join } = require('path');
+
+const version = process.argv[2];
+if (!version) {
+  console.error('Usage: node scripts/update-optional-deps.js <version>');
+  process.exit(1);
+}
+
+const pkgPath = join(__dirname, '..', 'package.json');
+const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+
+for (const dep of Object.keys(pkg.optionalDependencies)) {
+  pkg.optionalDependencies[dep] = version;
+}
+
+writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+console.log(`Updated optionalDependencies to ${version}`);

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,0 +1,152 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+
+// Mock fs and child_process before any imports so Jest intercepts them
+jest.mock('fs', () => ({
+  ...jest.requireActual<typeof import('fs')>('fs'),
+  existsSync: jest.fn(),
+  mkdirSync: jest.fn(),
+  copyFileSync: jest.fn(),
+  chmodSync: jest.fn(),
+}));
+
+jest.mock('child_process', () => ({
+  spawn: jest.fn(),
+}));
+
+describe('start()', () => {
+  const baseEnv = { ...process.env };
+  const azureFunctionEnv = {
+    FUNCTIONS_EXTENSION_VERSION: '~4',
+    FUNCTIONS_WORKER_RUNTIME: 'node',
+  };
+
+  let mockLogger: { debug: jest.Mock; info: jest.Mock; warn: jest.Mock; error: jest.Mock };
+  let existsSyncMock: jest.Mock;
+  let spawnMock: jest.Mock;
+  let start: (logger: typeof mockLogger) => void;
+
+  function setPlatform(platform: string) {
+    Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+  }
+
+  function setArch(arch: string) {
+    Object.defineProperty(process, 'arch', { value: arch, configurable: true });
+  }
+
+  beforeEach(() => {
+    process.env = { ...baseEnv, ...azureFunctionEnv };
+    setPlatform('linux');
+    setArch('x64');
+
+    jest.resetModules();
+
+    const fs = require('fs');
+    existsSyncMock = fs.existsSync as jest.Mock;
+
+    const cp = require('child_process');
+    spawnMock = cp.spawn as jest.Mock;
+    spawnMock.mockReturnValue(undefined);
+
+    start = require('./index').start;
+
+    mockLogger = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+  });
+
+  afterEach(() => {
+    process.env = baseEnv;
+    setPlatform(process.platform);
+    setArch(process.arch);
+    jest.restoreAllMocks();
+  });
+
+  it('logs a graceful error when the optional platform package is not installed', () => {
+    // No DD_SERVERLESS_COMPAT_PATH set and no optional package installed in test env
+    // → getBinaryPath() returns undefined
+    start(mockLogger);
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining('could not find platform binary package')
+    );
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('logs a graceful error when the resolved binary does not exist on disk', () => {
+    process.env.DD_SERVERLESS_COMPAT_PATH = '/some/path/to/binary';
+    existsSyncMock.mockReturnValue(false);
+
+    start(mockLogger);
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining('could not find binary at path /some/path/to/binary')
+    );
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('spawns the binary when DD_SERVERLESS_COMPAT_PATH points to an existing file', () => {
+    process.env.DD_SERVERLESS_COMPAT_PATH = '/some/path/to/binary';
+    existsSyncMock.mockReturnValue(true);
+
+    start(mockLogger);
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(mockLogger.error).not.toHaveBeenCalled();
+  });
+
+  it('does not start when no supported cloud environment is detected', () => {
+    delete process.env.FUNCTIONS_EXTENSION_VERSION;
+    delete process.env.FUNCTIONS_WORKER_RUNTIME;
+
+    start(mockLogger);
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Unknown environment detected')
+    );
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('does not start on unsupported platforms', () => {
+    setPlatform('darwin');
+    jest.resetModules();
+    start = require('./index').start;
+    process.env.DD_SERVERLESS_COMPAT_PATH = '/some/path/to/binary';
+
+    start(mockLogger);
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Platform darwin detected')
+    );
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('does not start on unsupported architectures', () => {
+    setArch('s390x');
+    jest.resetModules();
+    start = require('./index').start;
+    process.env.DD_SERVERLESS_COMPAT_PATH = '/some/path/to/binary';
+
+    start(mockLogger);
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Architecture s390x detected')
+    );
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('does not start Azure Flex when DD_AZURE_RESOURCE_GROUP is missing', () => {
+    process.env.WEBSITE_SKU = 'FlexConsumption';
+    process.env.DD_SERVERLESS_COMPAT_PATH = '/some/path/to/binary';
+    delete process.env.DD_AZURE_RESOURCE_GROUP;
+
+    start(mockLogger);
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining('DD_AZURE_RESOURCE_GROUP')
+    );
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,14 @@
 import { spawn } from 'child_process';
 import { existsSync, mkdirSync, copyFileSync, chmodSync } from 'fs';
 import { tmpdir } from 'os';
-import { resolve, join, basename } from 'path';
+import { join, basename, dirname } from 'path';
 import { logger, Logger } from './utils/log';
 import { LIB_VERSION as packageVersion } from './version';
 
 const defaultLogger = logger(__filename);
 
 enum CloudEnvironment {
+  AWS = 'AWS',
   AZURE_FUNCTION = 'Azure Function',
   GOOGLE_CLOUD_RUN_FUNCTION_1ST_GEN = 'Google Cloud Run Function 1st gen',
   GOOGLE_CLOUD_RUN_FUNCTION_2ND_GEN = 'Google Cloud Run Function 2nd gen',
@@ -15,6 +16,10 @@ enum CloudEnvironment {
 }
 
 function getEnvironment(): CloudEnvironment {
+  if (process.env.AWS_LAMBDA_INITIALIZATION_TYPE != undefined) {
+    return CloudEnvironment.AWS
+  }
+
   if (
     process.env.FUNCTIONS_EXTENSION_VERSION !== undefined &&
     process.env.FUNCTIONS_WORKER_RUNTIME !== undefined
@@ -39,20 +44,39 @@ function getEnvironment(): CloudEnvironment {
   return CloudEnvironment.UNKNOWN;
 }
 
-function getBinaryPath(): string {
-  if (process.env.DD_SERVERLESS_COMPAT_PATH !== undefined) {
-    return process.env.DD_SERVERLESS_COMPAT_PATH;
+let resolvedBinaryPath: string | undefined;
+
+function getBinaryPath(logger: Logger = defaultLogger): string | undefined {
+  if (resolvedBinaryPath !== undefined) {
+    return resolvedBinaryPath;
   }
 
-  const binaryPathOsFolder =
-    process.platform === 'win32'
-      ? resolve(__dirname, '..', 'bin', 'windows-amd64')
-      : resolve(__dirname, '..', 'bin', 'linux-amd64');
+  if (process.env.DD_SERVERLESS_COMPAT_PATH !== undefined) {
+    logger.debug(`Using DD_SERVERLESS_COMPAT_PATH: ${process.env.DD_SERVERLESS_COMPAT_PATH}`);
+    resolvedBinaryPath = process.env.DD_SERVERLESS_COMPAT_PATH;
+    return resolvedBinaryPath;
+  }
+
+  // npm/Node.js cpu convention: 'x64' or 'arm64'
+  const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
+  logger.debug(`getBinaryPath - process.arch: ${process.arch}, selected arch: ${arch}`);
+
+  const osName = process.platform === 'win32' ? 'win32' : 'linux';
   const binaryExtension = process.platform === 'win32' ? '.exe' : '';
-  return join(
-    binaryPathOsFolder,
-    `datadog-serverless-compat${binaryExtension}`
-  );
+  const binaryFilename = `datadog-serverless-compat${binaryExtension}`;
+
+  // Resolve binary from the installed optional platform-specific package
+  const pkgName = `@datadog/serverless-compat-${osName}-${arch}`;
+  try {
+    const pkgJsonPath = require.resolve(`${pkgName}/package.json`);
+    resolvedBinaryPath = join(dirname(pkgJsonPath), 'bin', binaryFilename);
+    logger.debug(`getBinaryPath - resolved from ${pkgName}: ${resolvedBinaryPath}`);
+    return resolvedBinaryPath;
+  } catch {
+    logger.debug(`getBinaryPath - ${pkgName} not installed`);
+  }
+
+  return undefined;
 }
 
 function isAzureFlexWithoutDDAzureResourceGroup(): boolean {
@@ -74,10 +98,18 @@ function start(logger: Logger = defaultLogger): void {
   }
 
   logger.debug(`Platform detected: ${process.platform}`);
+  logger.debug(`Architecture detected: ${process.arch}`);
 
   if (process.platform !== 'win32' && process.platform !== 'linux') {
     logger.error(
       `Platform ${process.platform} detected, the Datadog Serverless Compatibility Layer is only supported on Windows and Linux`
+    );
+    return;
+  }
+
+  if (process.arch !== 'arm64' && process.arch !== 'x64') {
+    logger.error(
+      `Architecture ${process.arch} detected, the Datadog Serverless Compatibility Layer only supports x64 (AMD64) and arm64 (ARM64) architectures`
     );
     return;
   }
@@ -89,35 +121,41 @@ function start(logger: Logger = defaultLogger): void {
     return;
   }
 
-  const binaryPath = getBinaryPath();
-
-  if (!existsSync(binaryPath)) {
-    logger.error(
-      `Serverless Compatibility Layer did not start, could not find binary at path ${binaryPath}`
-    );
-    return;
-  }
-
-  logger.debug(`Found package version ${packageVersion}`);
-
   try {
+    const binaryPath = getBinaryPath(logger);
+    if (binaryPath === undefined || !existsSync(binaryPath)) {
+      logger.error(
+        `Serverless Compatibility Layer did not start, ${binaryPath === undefined
+          ? 'could not find platform binary package'
+          : `could not find binary at path ${binaryPath}`}`
+      );
+      return;
+    }
+    logger.debug(`Selected binary path: ${binaryPath}`);
+
+    logger.debug(`Found package version ${packageVersion}`);
+
     const tempDir = join(tmpdir(), 'datadog');
     mkdirSync(tempDir, { recursive: true });
-
     const executableFilePath = join(tempDir, basename(binaryPath));
+    // TODO: check if binaryPath already has execute permissions and spawn it
+    // directly if so, skipping the copy+chmod to reduce cold-start overhead.
+    // Fall back to the copy+chmod path for read-only node_modules mounts or
+    // when the execute bit is not set.
     copyFileSync(binaryPath, executableFilePath);
     chmodSync(executableFilePath, 0o744);
-
     logger.debug(`Spawning process from binary at path ${executableFilePath}`);
 
     const env = {
       ...process.env,
       DD_SERVERLESS_COMPAT_VERSION: packageVersion,
     };
+    // TODO: add error and exit event handlers on the child process to log
+    // spawn failures and non-zero exit codes / termination signals gracefully.
     spawn(executableFilePath, { stdio: 'inherit', env });
   } catch (err) {
     logger.error(
-      `An unexpected error occurred while spawning Serverless Compatibility Layer process: ${err}`
+      `An unexpected error occurred while starting the Serverless Compatibility Layer: ${err}`
     );
   }
 }


### PR DESCRIPTION
### What does this PR do?

Ships platform-specific binaries via optional npm packages instead of bundling all binaries in the main package:

- \`@datadog/serverless-compat-linux-x64\`
- \`@datadog/serverless-compat-linux-arm64\`
- \`@datadog/serverless-compat-win32-x64\`

npm/yarn/pnpm automatically install only the package matching the current platform via \`os\`/\`cpu\` fields — no scripts needed. The binary is resolved at runtime via \`require.resolve()\`.

### Motivation

Users currently receive binaries for all platforms. This change ensures they only get the one they need.

Related: [SVLS-8608](https://datadoghq.atlassian.net/browse/SVLS-8608)
Depends on: [DataDog/serverless-components#100](https://github.com/DataDog/serverless-components/pull/100)

### Changes

- \`src/index.ts\`: updated \`getBinaryPath()\` to resolve from the optional platform package; returns \`undefined\` gracefully if not installed
- \`publish.yml\`: simplified — auto-detects version from registry, deduplicates build/publish jobs, fixes artifact action SHA, extracts inline scripts
- \`scripts/generate-version.js\`, \`scripts/update-optional-deps.js\`: extracted from inline CI commands
- \`src/index.spec.ts\`: new unit tests for \`start()\` covering key paths including missing optional package

### Testing

```
yarn build
yarn test  # 22 tests
```

[SVLS-8608]: https://datadoghq.atlassian.net/browse/SVLS-8608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ