### PR TITLE
feat: ship platform-specific binaries via optional packages and postinstall

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,17 +20,20 @@ on:
 permissions: {}
 
 jobs:
-  downloadbinaries:
+  build:
     runs-on: ubuntu-latest
     outputs:
-      package-version: ${{ steps.package.outputs.package-version }}
-      serverless-compat-version: ${{ steps.serverless-compat-binary.outputs.serverless-compat-version }}
+      package-version: ${{ steps.version.outputs.package-version }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - id: package
+        with:
+          fetch-depth: 0
+      - id: version
+        env:
+          VERSION_OVERRIDE: ${{ github.event.inputs.package-version-override }}
         run: |
-          if [[ -n "${{ github.event.inputs.package-version-override }}" ]]; then
-            PACKAGE_VERSION="${{ github.event.inputs.package-version-override }}"
+          if [[ -n "$VERSION_OVERRIDE" ]]; then
+            PACKAGE_VERSION="$VERSION_OVERRIDE"
           else
             if [[ ! "$GITHUB_REF" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+(-.+)?$ ]]; then
               echo "Invalid tag format: $GITHUB_REF, must be in the form vMAJOR.MINOR.PATCH"
@@ -38,38 +41,14 @@ jobs:
             fi
             PACKAGE_VERSION="${GITHUB_REF#refs/tags/v}"
           fi
-
           echo "package-version=$PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
-      - id: serverless-compat-binary
-        run: |
-          RESPONSE=$(curl -s "https://api.github.com/repos/datadog/serverless-components/releases")
-          SERVERLESS_COMPAT_VERSION=$(echo "$RESPONSE" | jq -r --arg pattern "datadog-serverless-compat\/v[0-9]*\.[0-9]*\.[0-9]*" '.[] | select(.tag_name | test($pattern)) | .tag_name' | sort -V | tail -n 1)
-
-          echo "Using version ${SERVERLESS_COMPAT_VERSION} of Serverless Compatibility Layer binary"
-          echo "serverless-compat-version=$(echo "$SERVERLESS_COMPAT_VERSION" | jq -rR 'ltrimstr("sls-")')" >> "$GITHUB_OUTPUT"
-
-          curl --output-dir ./temp/ --create-dirs -O -s -L "https://github.com/DataDog/serverless-components/releases/download/${SERVERLESS_COMPAT_VERSION}/datadog-serverless-compat.zip"
-          unzip ./temp/datadog-serverless-compat.zip -d ./
-      - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        with:
-          name: bin
-          path: bin
-  build:
-    runs-on: ubuntu-latest
-    needs: [downloadbinaries]
-    env:
-      PACKAGE_VERSION: ${{ needs.downloadbinaries.outputs.package-version }}
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: "18.x"
-      - run: yarn version ${{ env.PACKAGE_VERSION }}
+      - env:
+          PACKAGE_VERSION: ${{ steps.version.outputs.package-version }}
+        run: yarn version "$PACKAGE_VERSION"
       - run: yarn
-      - run: yarn prebuild
       - run: yarn build
       - run: yarn pack
       - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
@@ -81,35 +60,32 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-    needs: [downloadbinaries]
+    needs: [build]
     env:
-      PACKAGE_VERSION: ${{ needs.downloadbinaries.outputs.package-version }}
+      PACKAGE_VERSION: ${{ needs.build.outputs.package-version }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: "18.x"
-      - run: yarn version ${{ env.PACKAGE_VERSION }}
+      - run: yarn version "$PACKAGE_VERSION"
       - run: yarn
-      - run: yarn prebuild
       - run: yarn build
       - run: yarn npm publish
   release:
     if: ${{ github.event.inputs.publish-package == 'Build and Publish' }}
     runs-on: ubuntu-latest
-    needs: [downloadbinaries, build, publish]
+    needs: [build, publish]
     permissions:
       contents: write
     env:
-      PACKAGE_VERSION: ${{ needs.downloadbinaries.outputs.package-version }}
-      SERVERLESS_COMPAT_VERSION: ${{ needs.downloadbinaries.outputs.serverless-compat-version }}
+      PACKAGE_VERSION: ${{ needs.build.outputs.package-version }}
     steps:
       - uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # v2.1.0
         with:
-          body: "Uses [${{ env.SERVERLESS_COMPAT_VERSION }}](https://github.com/DataDog/serverless-components/releases/tag/${{ env.SERVERLESS_COMPAT_VERSION }}) of the Serverless Compatibility Layer binary."
+          body: "Binary downloaded at install time from the [datadog-serverless-compat/v${{ env.PACKAGE_VERSION }}](https://github.com/DataDog/serverless-components/releases/tag/datadog-serverless-compat%2Fv${{ env.PACKAGE_VERSION }}) release."
           draft: true
           tag_name: "v${{ env.PACKAGE_VERSION }}"
           generate_release_notes: true

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "build": "tsc",
     "clean": "rimraf dist",
     "lint": "node scripts/check_licenses.js && yarn run eslint . && yarn npm audit",
+    "pack-local": "yarn build && yarn pack",
+    "ensure-binary": "node scripts/postinstall.js",
+    "postinstall": "node scripts/postinstall.js",
     "prebuild": "node -p \"'export const LIB_VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > src/version.ts",
     "test": "jest"
   },
@@ -21,17 +24,13 @@
   "packageManager": "yarn@4.12.0",
   "files": [
     "dist/**/*",
-    "bin/**/*",
     "init.js",
+    "scripts/postinstall.js",
     "LICENSE-3rdparty.csv",
     "NOTICE"
   ],
   "publishConfig": {
-    "access": "public",
-    "executableFiles": [
-      "./bin/linux-amd64/datadog-serverless-compat",
-      "./bin/windows-amd64/datadog-serverless-compat.exe"
-    ]
+    "access": "public"
   },
   "bugs": {
     "url": "https://github.com/DataDog/datadog-serverless-compat-js/issues"

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,114 @@
+'use strict';
+
+// Downloads the platform-specific binary from GitHub Releases and places it
+// into this package's bin/ directory so getBinaryPath() can locate it at runtime.
+//
+// The release artifact naming convention is:
+//   datadog-serverless-compat-{linux|windows}-{amd64|arm64}.zip
+// Each zip contains a single file: datadog-serverless-compat[.exe]
+//
+// Runs silently if the platform is not supported (e.g. macOS in local dev).
+// Runs silently on network or extraction errors to avoid blocking installs.
+//
+// DD_SERVERLESS_COMPAT_BINARY_BASE_URL overrides the download base URL.
+// Useful for local testing (point at a local HTTP server) or air-gapped envs.
+// When set, the platform check is also skipped so macOS can be used for testing.
+// Example: DD_SERVERLESS_COMPAT_BINARY_BASE_URL=http://localhost:8080 node scripts/postinstall.js
+
+const { mkdirSync, chmodSync, createWriteStream, unlinkSync } = require('fs');
+const { join } = require('path');
+const { execFileSync } = require('child_process');
+const https = require('https');
+const http = require('http');
+const os = require('os');
+
+const arch = process.arch === 'arm64' ? 'arm64' : 'amd64';
+const osName = process.platform === 'win32' ? 'windows' : 'linux';
+const binaryExtension = process.platform === 'win32' ? '.exe' : '';
+const binaryFilename = `datadog-serverless-compat${binaryExtension}`;
+const zipFilename = `datadog-serverless-compat-${osName}-${arch}.zip`;
+
+const baseUrlOverride = process.env.DD_SERVERLESS_COMPAT_BINARY_BASE_URL;
+
+// Only supported on Linux and Windows; exit silently on macOS in normal installs.
+// Skip this check when a base URL override is set (e.g. local testing on macOS).
+if (!baseUrlOverride && process.platform !== 'linux' && process.platform !== 'win32') {
+  process.exit(0);
+}
+
+const { version } = require('../package.json');
+const releaseTag = `datadog-serverless-compat/v${version}`;
+const defaultBaseUrl = `https://github.com/DataDog/serverless-components/releases/download/${encodeURIComponent(releaseTag)}`;
+const downloadUrl = `${baseUrlOverride ?? defaultBaseUrl}/${zipFilename}`;
+
+const destDir = join(__dirname, '..', 'bin');
+const destPath = join(destDir, binaryFilename);
+const tmpZipPath = join(os.tmpdir(), `dd-serverless-compat-${process.pid}.zip`);
+
+function download(url, dest, redirects) {
+  return new Promise((resolve, reject) => {
+    if (redirects > 5) {
+      reject(new Error('Too many redirects'));
+      return;
+    }
+    const client = url.startsWith('https') ? https : http;
+    client
+      .get(url, (res) => {
+        if (res.statusCode === 301 || res.statusCode === 302) {
+          res.resume(); // drain the response
+          resolve(download(res.headers.location, dest, redirects + 1));
+          return;
+        }
+        if (res.statusCode !== 200) {
+          res.resume();
+          reject(new Error(`HTTP ${res.statusCode} downloading ${url}`));
+          return;
+        }
+        const file = createWriteStream(dest);
+        res.pipe(file);
+        file.on('finish', () => file.close(resolve));
+        file.on('error', reject);
+      })
+      .on('error', reject);
+  });
+}
+
+function extractZip(zipPath, filename, outDir) {
+  if (process.platform === 'win32') {
+    // PowerShell is available on all modern Windows installations.
+    execFileSync('powershell', [
+      '-NoProfile',
+      '-Command',
+      `Expand-Archive -LiteralPath "${zipPath}" -DestinationPath "${outDir}" -Force`,
+    ]);
+  } else {
+    // -o: overwrite, -j: junk (strip) paths inside the zip
+    execFileSync('unzip', ['-o', '-j', zipPath, filename, '-d', outDir]);
+  }
+}
+
+async function main() {
+  mkdirSync(destDir, { recursive: true });
+
+  await download(downloadUrl, tmpZipPath, 0);
+
+  try {
+    extractZip(tmpZipPath, binaryFilename, destDir);
+  } finally {
+    try {
+      unlinkSync(tmpZipPath);
+    } catch {
+      // best-effort cleanup
+    }
+  }
+
+  if (process.platform !== 'win32') {
+    chmodSync(destPath, 0o755);
+  }
+}
+
+main().catch(() => {
+  // Fail silently — start() will report a missing binary at runtime with a
+  // clear error message guiding the user.
+  process.exit(0);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,15 +44,19 @@ function getBinaryPath(): string {
     return process.env.DD_SERVERLESS_COMPAT_PATH;
   }
 
-  const binaryPathOsFolder =
-    process.platform === 'win32'
-      ? resolve(__dirname, '..', 'bin', 'windows-amd64')
-      : resolve(__dirname, '..', 'bin', 'linux-amd64');
   const binaryExtension = process.platform === 'win32' ? '.exe' : '';
-  return join(
-    binaryPathOsFolder,
-    `datadog-serverless-compat${binaryExtension}`
-  );
+  const binaryFilename = `datadog-serverless-compat${binaryExtension}`;
+
+  // Primary: flat bin/ populated by postinstall script
+  const postinstallPath = resolve(__dirname, '..', 'bin', binaryFilename);
+  if (existsSync(postinstallPath)) {
+    return postinstallPath;
+  }
+
+  // Fallback: nested bin/{os}-{arch}/ for local development via download_binaries.sh
+  const legacyArch = process.arch === 'arm64' ? 'arm64' : 'amd64';
+  const legacyOsPrefix = process.platform === 'win32' ? 'windows' : 'linux';
+  return join(resolve(__dirname, '..', 'bin', `${legacyOsPrefix}-${legacyArch}`), binaryFilename);
 }
 
 function isAzureFlexWithoutDDAzureResourceGroup(): boolean {
@@ -93,7 +97,8 @@ function start(logger: Logger = defaultLogger): void {
 
   if (!existsSync(binaryPath)) {
     logger.error(
-      `Serverless Compatibility Layer did not start, could not find binary at path ${binaryPath}`
+      `Serverless Compatibility Layer did not start, could not find binary at path ${binaryPath}. ` +
+      `If you installed with --ignore-scripts, run: yarn ensure-binary (or: node node_modules/@datadog/serverless-compat/scripts/postinstall.js)`
     );
     return;
   }


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/SVLS-8575

### What does this PR do?

Splits the native binaries out of the main `@datadog/serverless-compat` package into three separate platform-specific optional packages:

- `@datadog/serverless-compat-linux-x64`
- `@datadog/serverless-compat-linux-arm64`
- `@datadog/serverless-compat-win32-x64`

A `postinstall` script copies the matching binary into the main package's `bin/` directory at install time. At runtime, `getBinaryPath()` remains pure string construction with zero I/O overhead.

### Motivation

The current package bundles all platform binaries, making it larger than necessary. Users on any given platform only need one binary. This follows the same pattern used by `esbuild` and `@swc/core`.

Related: [SVLS-8608](https://datadoghq.atlassian.net/browse/SVLS-8608)

### Additional Notes

- No user-facing changes: same package name, same `start()` API, same `--require` preload support, same `DD_SERVERLESS_COMPAT_PATH` override
- `postinstall` runs automatically on `npm install` — users do nothing differently
- Users with `--ignore-scripts` will not have the binary copied; `start()` logs a clear error and no-ops (same behavior as `--no-optional`)
- CI publishes platform packages before the main package to ensure they exist on the registry when postinstall runs
- Local dev workflow via `download_binaries.sh` is unchanged — fallback path in `getBinaryPath()` finds binaries in `bin/{os}-{arch}/`
- See `docs/platform-packages-plan.md` for full design documentation including a potential enhancement to also support `--ignore-scripts` via a runtime fallback

### Describe how to test/QA your changes

- Run `yarn build` and verify compilation succeeds
- Run `yarn test` and verify all tests pass
- Install the package locally with one of the platform packages present and verify `bin/datadog-serverless-compat` is populated by postinstall
- Trigger the publish workflow with "Build" mode and verify binaries are correctly copied into platform package directories