### PR TITLE
feat(platform): add macOS arm64 and Windows ia32 support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,9 +49,9 @@ jobs:
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: "18.x"
-      - run: yarn version $PACKAGE_VERSION
       - name: Update optionalDependencies to match package version
-        run: yarn update-optional-deps "$PACKAGE_VERSION"
+        run: node scripts/update-optional-deps.js "$PACKAGE_VERSION"
+      - run: yarn version $PACKAGE_VERSION
       - run: yarn
       - run: yarn prebuild
       - run: yarn build

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
   "optionalDependencies": {
     "@datadog/serverless-compat-linux-x64": "0.0.0",
     "@datadog/serverless-compat-linux-arm64": "0.0.0",
-    "@datadog/serverless-compat-win32-x64": "0.0.0"
+    "@datadog/serverless-compat-win32-x64": "0.0.0",
+    "@datadog/serverless-compat-win32-ia32": "0.0.0",
+    "@datadog/serverless-compat-darwin-arm64": "0.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -110,7 +110,7 @@ describe('start()', () => {
   });
 
   it('does not start on unsupported platforms', () => {
-    setPlatform('darwin');
+    setPlatform('freebsd');
     jest.resetModules();
     start = require('./index').start;
     process.env.DD_SERVERLESS_COMPAT_PATH = '/some/path/to/binary';
@@ -118,7 +118,7 @@ describe('start()', () => {
     start(mockLogger);
 
     expect(mockLogger.error).toHaveBeenCalledWith(
-      expect.stringContaining('Platform darwin detected')
+      expect.stringContaining('Platform/architecture freebsd/')
     );
     expect(spawnMock).not.toHaveBeenCalled();
   });
@@ -132,9 +132,75 @@ describe('start()', () => {
     start(mockLogger);
 
     expect(mockLogger.error).toHaveBeenCalledWith(
-      expect.stringContaining('Architecture s390x detected')
+      expect.stringContaining('/s390x is not supported')
     );
     expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('does not start on macOS x64 (Intel)', () => {
+    setPlatform('darwin');
+    setArch('x64');
+    jest.resetModules();
+    start = require('./index').start;
+    process.env.DD_SERVERLESS_COMPAT_PATH = '/some/path/to/binary';
+
+    start(mockLogger);
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Platform/architecture darwin/x64 is not supported')
+    );
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('does not start on Linux ia32 (no binary available)', () => {
+    setPlatform('linux');
+    setArch('ia32');
+    jest.resetModules();
+    start = require('./index').start;
+    process.env.DD_SERVERLESS_COMPAT_PATH = '/some/path/to/binary';
+
+    start(mockLogger);
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Platform/architecture linux/ia32 is not supported')
+    );
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('spawns the binary on macOS arm64 when DD_SERVERLESS_COMPAT_PATH points to an existing file', () => {
+    setPlatform('darwin');
+    setArch('arm64');
+    jest.resetModules();
+    start = require('./index').start;
+    process.env.DD_SERVERLESS_COMPAT_PATH = '/some/path/to/binary';
+
+    const fs = require('fs');
+    (fs.existsSync as jest.Mock).mockReturnValue(true);
+    const cp = require('child_process');
+    (cp.spawn as jest.Mock).mockReturnValue(undefined);
+
+    start(mockLogger);
+
+    expect(cp.spawn).toHaveBeenCalledTimes(1);
+    expect(mockLogger.error).not.toHaveBeenCalled();
+  });
+
+  it('spawns the binary on Windows ia32 when DD_SERVERLESS_COMPAT_PATH points to an existing file', () => {
+    setPlatform('win32');
+    setArch('ia32');
+    jest.resetModules();
+    start = require('./index').start;
+    process.env.DD_SERVERLESS_COMPAT_PATH = '/some/path/to/binary';
+
+    const fs = require('fs');
+    (fs.existsSync as jest.Mock).mockReturnValue(true);
+    const cp = require('child_process');
+    (cp.spawn as jest.Mock).mockReturnValue(undefined);
+
+    start(mockLogger);
+
+    expect(cp.spawn).toHaveBeenCalledTimes(1);
+    expect(mockLogger.error).not.toHaveBeenCalled();
   });
 
   it('does not start Azure Flex when DD_AZURE_RESOURCE_GROUP is missing', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,11 +57,11 @@ function getBinaryPath(logger: Logger = defaultLogger): string | undefined {
     return resolvedBinaryPath;
   }
 
-  // npm/Node.js cpu convention: 'x64' or 'arm64'
-  const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
+  // npm/Node.js cpu convention: 'x64', 'arm64', or 'ia32'
+  const arch = process.arch === 'arm64' ? 'arm64' : process.arch === 'ia32' ? 'ia32' : 'x64';
   logger.debug(`getBinaryPath - process.arch: ${process.arch}, selected arch: ${arch}`);
 
-  const osName = process.platform === 'win32' ? 'win32' : 'linux';
+  const osName = process.platform === 'win32' ? 'win32' : process.platform === 'darwin' ? 'darwin' : 'linux';
   const binaryExtension = process.platform === 'win32' ? '.exe' : '';
   const binaryFilename = `datadog-serverless-compat${binaryExtension}`;
 
@@ -100,16 +100,17 @@ function start(logger: Logger = defaultLogger): void {
   logger.debug(`Platform detected: ${process.platform}`);
   logger.debug(`Architecture detected: ${process.arch}`);
 
-  if (process.platform !== 'win32' && process.platform !== 'linux') {
-    logger.error(
-      `Platform ${process.platform} detected, the Datadog Serverless Compatibility Layer is only supported on Windows and Linux`
-    );
-    return;
-  }
+  const supportedPlatformArchPairs = new Set([
+    'linux-x64',
+    'linux-arm64',
+    'win32-x64',
+    'win32-ia32',
+    'darwin-arm64',
+  ]);
 
-  if (process.arch !== 'arm64' && process.arch !== 'x64') {
+  if (!supportedPlatformArchPairs.has(`${process.platform}-${process.arch}`)) {
     logger.error(
-      `Architecture ${process.arch} detected, the Datadog Serverless Compatibility Layer only supports x64 (AMD64) and arm64 (ARM64) architectures`
+      `Platform/architecture ${process.platform}/${process.arch} is not supported by the Datadog Serverless Compatibility Layer`
     );
     return;
   }


### PR DESCRIPTION
## Description
Extends the Datadog Serverless Compatibility Layer to support two new platforms:
- **macOS arm64** (Apple Silicon) — `@datadog/serverless-compat-darwin-arm64`
- **Windows ia32** (32-bit) — `@datadog/serverless-compat-win32-ia32`

macOS Intel (x64) is intentionally **not** supported. A clear error is produced for that case rather than the misleading "could not find platform binary package" message.

## Motivation
[SVLS-8575](https://datadoghq.atlassian.net/browse/SVLS-8575)

## Changes
- `src/index.ts` — replace three sequential platform/arch guards with a single `supportedPlatformArchPairs` Set allowlist; update `getBinaryPath()` to resolve new package names
- `package.json` — register `@datadog/serverless-compat-darwin-arm64` and `@datadog/serverless-compat-win32-ia32` as optional dependencies
- `src/index.spec.ts` — update test expectations to match new error message format; add regression test for `linux/ia32` (previously passed the arch guard but had no binary, now rejected upfront)

## Testing
- All 26 Jest tests pass (`yarn test`)
- Explicit test cases for: darwin-arm64 success, win32-ia32 success, darwin-x64 rejection, linux-ia32 rejection

[SVLS-8575]: https://datadoghq.atlassian.net/browse/SVLS-8575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ