### PR TITLE
feat(ci): add pre-publish integration test matrix [SVLS-8575]

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,9 +49,9 @@ jobs:
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: "18.x"
-      - run: yarn version $PACKAGE_VERSION
       - name: Update optionalDependencies to match package version
-        run: yarn update-optional-deps "$PACKAGE_VERSION"
+        run: node scripts/update-optional-deps.js "$PACKAGE_VERSION"
+      - run: yarn version $PACKAGE_VERSION
       - run: yarn
       - run: yarn prebuild
       - run: yarn build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,12 +61,73 @@ jobs:
           name: package
           path: package.tgz
 
+  # Integration tests: simulate user experience on each native platform.
+  # npm installs the main package and auto-resolves the platform binary via
+  # optionalDependencies — exactly as a real user would. All legs are required
+  # and must pass before publish runs.
+  test:
+    needs: [build]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            node-arch: x64
+            required: true
+          - os: ubuntu-24.04-arm
+            node-arch: arm64
+            required: true
+          - os: macos-14              # pinned oldest supported arm64 runner for max compatibility
+            node-arch: arm64
+            required: true
+          - os: windows-latest
+            node-arch: x64
+            required: true
+          - os: windows-latest
+            node-arch: x86            # setup-node 'x86' → process.arch === 'ia32'
+            required: true
+    runs-on: ${{ matrix.os }}
+    name: test / ${{ matrix.os }} (${{ matrix.node-arch }})
+    continue-on-error: ${{ !matrix.required }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: "18.x"
+          architecture: ${{ matrix.node-arch }}
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: package
+      # Use $RUNNER_TEMP (not /tmp) — reliable across Linux, macOS, and Windows Git Bash.
+      - name: Create test app
+        shell: bash
+        run: |
+          mkdir -p "$RUNNER_TEMP/test-app"
+          echo '{"name":"test-app","version":"1.0.0","private":true}' > "$RUNNER_TEMP/test-app/package.json"
+      # npm reads optionalDependencies from the installed package and pulls the matching
+      # platform binary from the registry — true user-experience simulation.
+      # Use $GITHUB_WORKSPACE (not ${{ github.workspace }}) in bash steps — the Actions
+      # context variable uses backslashes on Windows, breaking forward-slash paths.
+      - name: Install main package
+        shell: bash
+        run: |
+          cd "$RUNNER_TEMP/test-app"
+          npm install "$GITHUB_WORKSPACE/package.tgz"
+      - name: Run binary integration test
+        shell: bash
+        run: |
+          # Copy script into test-app so require() resolves packages from
+          # test-app/node_modules, not from the workspace checkout.
+          cp "$GITHUB_WORKSPACE/test/integration/test-binary.js" "$RUNNER_TEMP/test-app/test-binary.js"
+          cd "$RUNNER_TEMP/test-app"
+          node test-binary.js
+
   publish:
     if: ${{ github.event.inputs.publish-package == 'Build and Publish' }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-    needs: [build]
+    needs: [test]
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
   "optionalDependencies": {
     "@datadog/serverless-compat-linux-x64": "0.0.0",
     "@datadog/serverless-compat-linux-arm64": "0.0.0",
-    "@datadog/serverless-compat-win32-x64": "0.0.0"
+    "@datadog/serverless-compat-win32-x64": "0.0.0",
+    "@datadog/serverless-compat-win32-ia32": "0.0.0",
+    "@datadog/serverless-compat-darwin-arm64": "0.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -110,7 +110,7 @@ describe('start()', () => {
   });
 
   it('does not start on unsupported platforms', () => {
-    setPlatform('darwin');
+    setPlatform('freebsd');
     jest.resetModules();
     start = require('./index').start;
     process.env.DD_SERVERLESS_COMPAT_PATH = '/some/path/to/binary';
@@ -118,7 +118,7 @@ describe('start()', () => {
     start(mockLogger);
 
     expect(mockLogger.error).toHaveBeenCalledWith(
-      expect.stringContaining('Platform darwin detected')
+      expect.stringContaining('Platform/architecture freebsd/')
     );
     expect(spawnMock).not.toHaveBeenCalled();
   });
@@ -132,9 +132,75 @@ describe('start()', () => {
     start(mockLogger);
 
     expect(mockLogger.error).toHaveBeenCalledWith(
-      expect.stringContaining('Architecture s390x detected')
+      expect.stringContaining('/s390x is not supported')
     );
     expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('does not start on macOS x64 (Intel)', () => {
+    setPlatform('darwin');
+    setArch('x64');
+    jest.resetModules();
+    start = require('./index').start;
+    process.env.DD_SERVERLESS_COMPAT_PATH = '/some/path/to/binary';
+
+    start(mockLogger);
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Platform/architecture darwin/x64 is not supported')
+    );
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('does not start on Linux ia32 (no binary available)', () => {
+    setPlatform('linux');
+    setArch('ia32');
+    jest.resetModules();
+    start = require('./index').start;
+    process.env.DD_SERVERLESS_COMPAT_PATH = '/some/path/to/binary';
+
+    start(mockLogger);
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Platform/architecture linux/ia32 is not supported')
+    );
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('spawns the binary on macOS arm64 when DD_SERVERLESS_COMPAT_PATH points to an existing file', () => {
+    setPlatform('darwin');
+    setArch('arm64');
+    jest.resetModules();
+    start = require('./index').start;
+    process.env.DD_SERVERLESS_COMPAT_PATH = '/some/path/to/binary';
+
+    const fs = require('fs');
+    (fs.existsSync as jest.Mock).mockReturnValue(true);
+    const cp = require('child_process');
+    (cp.spawn as jest.Mock).mockReturnValue(undefined);
+
+    start(mockLogger);
+
+    expect(cp.spawn).toHaveBeenCalledTimes(1);
+    expect(mockLogger.error).not.toHaveBeenCalled();
+  });
+
+  it('spawns the binary on Windows ia32 when DD_SERVERLESS_COMPAT_PATH points to an existing file', () => {
+    setPlatform('win32');
+    setArch('ia32');
+    jest.resetModules();
+    start = require('./index').start;
+    process.env.DD_SERVERLESS_COMPAT_PATH = '/some/path/to/binary';
+
+    const fs = require('fs');
+    (fs.existsSync as jest.Mock).mockReturnValue(true);
+    const cp = require('child_process');
+    (cp.spawn as jest.Mock).mockReturnValue(undefined);
+
+    start(mockLogger);
+
+    expect(cp.spawn).toHaveBeenCalledTimes(1);
+    expect(mockLogger.error).not.toHaveBeenCalled();
   });
 
   it('does not start Azure Flex when DD_AZURE_RESOURCE_GROUP is missing', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,11 +57,11 @@ function getBinaryPath(logger: Logger = defaultLogger): string | undefined {
     return resolvedBinaryPath;
   }
 
-  // npm/Node.js cpu convention: 'x64' or 'arm64'
-  const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
+  // npm/Node.js cpu convention: 'x64', 'arm64', or 'ia32'
+  const arch = process.arch === 'arm64' ? 'arm64' : process.arch === 'ia32' ? 'ia32' : 'x64';
   logger.debug(`getBinaryPath - process.arch: ${process.arch}, selected arch: ${arch}`);
 
-  const osName = process.platform === 'win32' ? 'win32' : 'linux';
+  const osName = process.platform === 'win32' ? 'win32' : process.platform === 'darwin' ? 'darwin' : 'linux';
   const binaryExtension = process.platform === 'win32' ? '.exe' : '';
   const binaryFilename = `datadog-serverless-compat${binaryExtension}`;
 
@@ -100,16 +100,17 @@ function start(logger: Logger = defaultLogger): void {
   logger.debug(`Platform detected: ${process.platform}`);
   logger.debug(`Architecture detected: ${process.arch}`);
 
-  if (process.platform !== 'win32' && process.platform !== 'linux') {
-    logger.error(
-      `Platform ${process.platform} detected, the Datadog Serverless Compatibility Layer is only supported on Windows and Linux`
-    );
-    return;
-  }
+  const supportedPlatformArchPairs = new Set([
+    'linux-x64',
+    'linux-arm64',
+    'win32-x64',
+    'win32-ia32',
+    'darwin-arm64',
+  ]);
 
-  if (process.arch !== 'arm64' && process.arch !== 'x64') {
+  if (!supportedPlatformArchPairs.has(`${process.platform}-${process.arch}`)) {
     logger.error(
-      `Architecture ${process.arch} detected, the Datadog Serverless Compatibility Layer only supports x64 (AMD64) and arm64 (ARM64) architectures`
+      `Platform/architecture ${process.platform}/${process.arch} is not supported by the Datadog Serverless Compatibility Layer`
     );
     return;
   }

--- a/test/integration/test-binary.js
+++ b/test/integration/test-binary.js
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+'use strict';
+
+// Integration test: verifies platform binary package resolution and crash-free startup.
+// Runs natively on the target OS — no Docker required.
+
+const { existsSync } = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+// ── 1. Determine expected package name from current platform ─────────────────
+const osName = process.platform; // 'linux', 'darwin', 'win32'
+const arch = process.arch === 'arm64' ? 'arm64' : process.arch === 'ia32' ? 'ia32' : 'x64';
+const pkgName = `@datadog/serverless-compat-${osName}-${arch}`;
+const binaryFilename = process.platform === 'win32'
+  ? 'datadog-serverless-compat.exe'
+  : 'datadog-serverless-compat';
+
+console.log(`\n=== Test: package resolution (${pkgName}) ===`);
+
+// ── 2. Verify require.resolve finds the platform package ────────────────────
+let pkgJsonPath;
+try {
+  pkgJsonPath = require.resolve(`${pkgName}/package.json`);
+} catch (e) {
+  console.error(`FAIL: ${pkgName} not resolvable — is it installed? ${e.message}`);
+  process.exit(1);
+}
+
+const pkgDir = path.dirname(pkgJsonPath);
+const binaryPath = path.join(pkgDir, 'bin', binaryFilename);
+
+console.log(`Platform pkg dir : ${pkgDir}`);
+console.log(`Binary path      : ${binaryPath}`);
+
+if (!existsSync(binaryPath)) {
+  console.error(`FAIL: binary not found at ${binaryPath}`);
+  process.exit(1);
+}
+console.log(`PASS: binary exists at ${binaryPath}`);
+
+// ── 3. Spawn the binary directly — check it does not crash ──────────────────
+console.log('\n=== Test: binary crash-free startup ===');
+
+// spawnSync with a short timeout: the binary is a long-running daemon so it won't
+// exit on its own. We give it 2s and then the timeout kills it.
+// Success = killed by timeout (ETIMEDOUT) or SIGTERM.
+// Failure = POSIX crash signal OR Windows structured-exception exit code (0xC0000xxx).
+const result = spawnSync(binaryPath, [], {
+  timeout: 2000,
+  stdio: 'pipe',
+  env: { ...process.env, DD_LOG_LEVEL: 'debug' },
+});
+
+// POSIX crash signals
+const CRASH_SIGNALS = new Set(['SIGSEGV', 'SIGABRT', 'SIGILL', 'SIGBUS']);
+
+// Windows structured-exception codes: 0xC0000000–0xCFFFFFFF are fatal crashes
+// e.g. 0xC0000005 = access violation, 0xC000001D = illegal instruction.
+// On Windows, result.signal is null for crashes; check status instead.
+const isWindowsCrashCode = (status) => {
+  if (process.platform !== 'win32' || typeof status !== 'number') return false;
+  const unsigned = status >>> 0; // convert signed int32 to unsigned uint32
+  return unsigned >= 0xC0000000 && unsigned <= 0xCFFFFFFF;
+};
+
+if (CRASH_SIGNALS.has(result.signal)) {
+  console.error(`FAIL: binary crashed with signal ${result.signal}`);
+  if (result.stderr) console.error(result.stderr.toString());
+  process.exit(1);
+}
+
+if (isWindowsCrashCode(result.status)) {
+  console.error(`FAIL: binary crashed with Windows exit code 0x${result.status.toString(16).toUpperCase()}`);
+  if (result.stderr) console.error(result.stderr.toString());
+  process.exit(1);
+}
+
+if (result.error && result.error.code !== 'ETIMEDOUT') {
+  console.error(`FAIL: unexpected spawn error: ${result.error}`);
+  process.exit(1);
+}
+
+// Catch early exits: if the binary exited before the timeout with a non-zero
+// status, it failed to start (e.g. missing config, bad binary). This catches
+// failures that produce no crash signal and no spawn error.
+if (!result.error && result.status !== null && result.status !== 0) {
+  console.error(`FAIL: binary exited early with status ${result.status}`);
+  if (result.stderr) console.error(result.stderr.toString());
+  process.exit(1);
+}
+
+console.log(`PASS: binary ran without crash (signal=${result.signal ?? 'none'}, status=${result.status ?? 'n/a'})`);
+
+// ── 4. Verify start() resolves and spawns the binary via @datadog/serverless-compat ──
+console.log('\n=== Test: start() integration ===');
+
+process.env.FUNCTIONS_EXTENSION_VERSION = '~4';
+process.env.FUNCTIONS_WORKER_RUNTIME = 'node';
+delete process.env.WEBSITE_SKU;
+process.env.DD_LOG_LEVEL = 'debug';
+
+const cp = require('child_process');
+const origSpawn = cp.spawn;
+let spawnOccurred = false;
+
+cp.spawn = function(cmd, ...args) {
+  console.log(`SPAWN intercepted: ${cmd}`);
+  spawnOccurred = true;
+  if (!cmd.includes('datadog-serverless-compat')) {
+    console.error(`FAIL: unexpected binary spawned: ${cmd}`);
+    process.exit(1);
+  }
+  if (!existsSync(cmd)) {
+    console.error(`FAIL: spawned path does not exist: ${cmd}`);
+    process.exit(1);
+  }
+  console.log('PASS: correct binary path spawned');
+  return origSpawn.call(this, cmd, ...args);
+};
+
+const { start } = require('@datadog/serverless-compat');
+start();
+
+setTimeout(() => {
+  if (!spawnOccurred) {
+    console.error('FAIL: start() did not call spawn()');
+    process.exit(1);
+  }
+  console.log('\n=== All tests passed ===');
+  process.exit(0);
+}, 1500);

--- a/test/integration/test-binary.js
+++ b/test/integration/test-binary.js
@@ -4,7 +4,7 @@
 // Integration test: verifies platform binary package resolution and crash-free startup.
 // Runs natively on the target OS — no Docker required.
 
-const { existsSync } = require('fs');
+const { existsSync, chmodSync } = require('fs');
 const path = require('path');
 const { spawnSync } = require('child_process');
 
@@ -41,6 +41,14 @@ console.log(`PASS: binary exists at ${binaryPath}`);
 
 // ── 3. Spawn the binary directly — check it does not crash ──────────────────
 console.log('\n=== Test: binary crash-free startup ===');
+
+// Ensure the binary is executable. npm is not guaranteed to preserve the execute
+// bit when installing from the registry, and start() always copies+chmods before
+// spawning for the same reason. Mirror that here so we test binary behavior, not
+// npm's file-mode handling.
+if (process.platform !== 'win32') {
+  chmodSync(binaryPath, 0o755);
+}
 
 // spawnSync with a short timeout: the binary is a long-running daemon so it won't
 // exit on its own. We give it 2s and then the timeout kills it.


### PR DESCRIPTION
## Summary
- Adds a multi-platform `test` job to `publish.yml` that gates publishing behind a real end-to-end binary check
- Covers linux-x64, linux-arm64, win32-x64 (required) + darwin-arm64, win32-ia32 (informational / `continue-on-error`)
- Adds `test/integration/test-binary.js`: simulates exact user experience — npm installs the packed `.tgz`, npm auto-resolves the platform binary via `optionalDependencies`, then verifies the binary exists, starts without crashing, and that `start()` spawns the correct path

## Motivation
Jira: https://datadoghq.atlassian.net/browse/SVLS-8575

Publishing was previously gated only on a TypeScript build step — no runtime verification. A broken binary could reach the registry undetected.

## Test plan
- [ ] Trigger the publish workflow in "Build" mode and confirm all required test legs (linux-x64, linux-arm64, win32-x64) pass
- [ ] Confirm darwin-arm64 and win32-ia32 legs run but do not block the workflow on failure
- [ ] Confirm the `publish` job is skipped (or blocked) when any required test leg fails

Test result:
https://github.com/DataDog/datadog-serverless-compat-js/actions/runs/23950204194
<img width="496" height="526" alt="image" src="https://github.com/user-attachments/assets/02ef9ae7-cb98-41b4-b5e6-00c257363a74" />

