### PR TITLE
[SVLS-8827] Add npm minimal age gate

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,5 @@
 nodeLinker: node-modules
 
+npmMinimalAgeGate: "2d"
+
 yarnPath: .yarn/releases/yarn-4.12.0.cjs


### PR DESCRIPTION
## Summary

Following the [supply chain attack on axios](https://socket.dev/blog/compromised-axios-npm-packages), adding `npmMinimalAgeGate: "2d"` to `.yarnrc.yml` to refuse NPM packages published less than 2 days ago during lockfile generation.

This is a config-only change with no functional impact.

## Jira

[SVLS-8827](https://datadoghq.atlassian.net/browse/SVLS-8827)